### PR TITLE
dev volatile

### DIFF
--- a/roles/neovim/files/lazy/lua/plugins/configs/render_markdown.lua
+++ b/roles/neovim/files/lazy/lua/plugins/configs/render_markdown.lua
@@ -1,0 +1,22 @@
+local M = {}
+
+M.opts = {
+  checkbox = {
+    enabled = true,
+    -- `bullet = true` and `right_pad = 2` makes line same width rendered and unrendered.
+    bullet = true,
+    right_pad = 2,
+  },
+  -- Prevent rendered and normal versions to be different in lines,
+  -- which makes document "flicker" when switching between them.
+  code = { border = "thick" },
+  pipe_table = { style = "normal" },
+  link = { enabled = false },
+  win_options = { conceallevel = { default = 0, rendered = 0 } },
+
+  file_types = { "markdown", "Avante" },
+}
+
+M.ft = { "markdown", "Avante" }
+
+return M

--- a/roles/neovim/files/lazy/lua/plugins/init.lua
+++ b/roles/neovim/files/lazy/lua/plugins/init.lua
@@ -67,22 +67,8 @@ return {
   },
   {
     "MeanderingProgrammer/render-markdown.nvim",
-    opts = {
-      checkbox = {
-        enabled = true,
-        -- `bullet = true` and `right_pad = 2` makes line same width rendered and unrendered.
-        bullet = true,
-        right_pad = 2,
-      },
-      -- Prevent rendered and normal versions to be different in lines,
-      -- which makes document "flicker" when switching between them.
-      code = { border = "thick" },
-      pipe_table = { style = "normal" },
-      link = { enabled = false },
-      win_options = { conceallevel = { default = 0, rendered = 0 } },
-      file_types = { "markdown", "Avante" },
-    },
-    ft = { "markdown", "Avante" },
+    opts = require("plugins.configs.render_markdown").opts,
+    ft = require("plugins.configs.render_markdown").ft,
   },
   {
     "mfussenegger/nvim-dap",

--- a/roles/neovim/files/lazy/lua/plugins/init.lua
+++ b/roles/neovim/files/lazy/lua/plugins/init.lua
@@ -68,10 +68,18 @@ return {
   {
     "MeanderingProgrammer/render-markdown.nvim",
     opts = {
+      checkbox = {
+        enabled = true,
+        -- `bullet = true` and `right_pad = 2` makes line same width rendered and unrendered.
+        bullet = true,
+        right_pad = 2,
+      },
       -- Prevent rendered and normal versions to be different in lines,
       -- which makes document "flicker" when switching between them.
       code = { border = "thick" },
       pipe_table = { style = "normal" },
+      link = { enabled = false },
+      win_options = { conceallevel = { default = 0, rendered = 0 } },
       file_types = { "markdown", "Avante" },
     },
     ft = { "markdown", "Avante" },


### PR DESCRIPTION
- **refactor(neovim): make render-markdown less flickery**
- **refactor(neovim): move out render-markdown config**
