### PR TITLE
dev volatile

### DIFF
--- a/nix/home-manager/programs/neovim.nix
+++ b/nix/home-manager/programs/neovim.nix
@@ -12,10 +12,13 @@
       "--run"
       ''
         if [[ "$USERKIND" == "default" ]]; then
-          source $(${pkgs.sops-cached}/bin/sops-cached ${../secrets/proxy.sh.sops})
-          source $(${pkgs.sops-cached}/bin/sops-cached ${../secrets/keys.sh.sops})
+          # shellcheck source=/dev/null
+          source "$(${pkgs.sops-cached}/bin/sops-cached ${../secrets/proxy.sh.sops})"
+          # shellcheck source=/dev/null
+          source "$(${pkgs.sops-cached}/bin/sops-cached ${../secrets/keys.sh.sops})"
         elif [[ "$USERKIND" == "corp" ]]; then
-          source $(${pkgs.sops-cached}/bin/sops-cached ${../secrets/corp_keys.sh.sops})
+          # shellcheck source=/dev/null
+          source "$(${pkgs.sops-cached}/bin/sops-cached ${../secrets/corp_keys.sh.sops})"
         fi
       ''
     ];

--- a/nix/home-manager/programs/neovim.nix
+++ b/nix/home-manager/programs/neovim.nix
@@ -20,6 +20,9 @@
           # shellcheck source=/dev/null
           source "$(${pkgs.sops-cached}/bin/sops-cached ${../secrets/corp_keys.sh.sops})"
         fi
+
+        # Workaround for https://github.com/iamcco/markdown-preview.nvim/issues/737
+        export NVIM_MKDP_LOG_FILE="/tmp/mkdp-nvim-$USER.log"
       ''
     ];
 


### PR DESCRIPTION
- **refactor(neovim): amend shellcheck warns in nvim wrapper**
- **fix(neovim): fix markdown-preview issue with inaccessible logs**
