### PR TITLE
refactor(system): add networkmanager plugins

### DIFF
--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -50,7 +50,11 @@
     hostName = "nixos";
     networkmanager = {
       enable = true;
-      plugins = with pkgs; [ networkmanager-openvpn ];
+      plugins = with pkgs; [
+        networkmanager-openconnect
+        networkmanager-openvpn
+        networkmanager-ssh
+      ];
     };
   };
 


### PR DESCRIPTION
Turns out it is possible to use Gnome's native GUI for openconnect...
