### PR TITLE
refactor(libs): use boost.dev instead of boost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,7 @@ The GitHub Actions workflow (`.github/workflows/workflow.yml`) runs on all PRs a
 - Custom keyboard layouts via xkb
 - Fish shell is primary shell (11 .fish files)
 - Neovim config based on LazyVim
+- NOTE: WHEN ADDING NEW NIX OR CONFIG FILE, ADD IT TO GIT STAGING AREA. OTHERWISE NIX WILL NOT SEE IT.
 
 ### Important File Locations
 

--- a/dotfiles_py/cli.py
+++ b/dotfiles_py/cli.py
@@ -122,9 +122,10 @@ def syms() -> None:
         source_dir=REPO_PATH / "nix/home-manager/programs/editors/neovim/config",
         target_dir=xdg_config_home / "nvim",
     )
+    syms_target.create_symlinks(source_dir=REPO_PATH / "nix/home-manager/programs/ai/configs")
+    syms_target.create_symlinks(source_dir=REPO_PATH / "nix/home-manager/programs/linters/configs")
     syms_target.create_symlinks(source_dir=REPO_PATH / "nix/home-manager/programs/shell/television")
     syms_target.create_symlinks(source_dir=REPO_PATH / "nix/home-manager/programs/system/configs")
-    syms_target.create_symlinks(source_dir=REPO_PATH / "nix/home-manager/programs/ai/configs")
 
 
 @app.command()

--- a/nix/home-manager/programs/editors/neovim/config/lua/plugins/configs/tmux.lua
+++ b/nix/home-manager/programs/editors/neovim/config/lua/plugins/configs/tmux.lua
@@ -1,43 +1,5 @@
 local M = {}
 
--- https://github.com/folke/snacks.nvim/discussions/1802
--- https://github.com/aserowy/tmux.nvim/issues/133
--- https://github.com/folke/snacks.nvim/issues/1350
--- https://github.com/folke/snacks.nvim/discussions/1332
-
-local function is_snacks_explorer()
-  if not Snacks then
-    return false
-  end
-  local is_explorer = vim.iter(Snacks.picker.get({ source = "explorer" })):any(function(picker)
-    return picker:is_focused()
-  end)
-  return is_explorer
-end
-local function is_nvim_float()
-  if is_snacks_explorer() then
-    return false
-  end
-  return require("tmux.wrapper.nvim").is_nvim_float_original()
-end
-local function is_nvim_border(border)
-  if is_snacks_explorer() and border == "h" then
-    return true
-  end
-  return require("tmux.wrapper.nvim").is_nvim_border_original(border)
-end
-
-M.config = function(_, opts)
-  require("tmux").setup(opts)
-
-  local tmux_nvim = require("tmux.wrapper.nvim")
-
-  tmux_nvim.is_nvim_float_original = tmux_nvim.is_nvim_float
-  tmux_nvim.is_nvim_float = is_nvim_float
-  tmux_nvim.is_nvim_border_original = tmux_nvim.is_nvim_border
-  tmux_nvim.is_nvim_border = is_nvim_border
-end
-
 M.opts = {
   navigation = {
     enable_default_keybindings = false,
@@ -51,16 +13,7 @@ local function tmux_move(direction, key)
   return {
     key,
     function()
-      local tmux = require("tmux")
-      if direction == "left" then
-        tmux.move_left()
-      elseif direction == "right" then
-        tmux.move_right()
-      elseif direction == "bottom" then
-        tmux.move_bottom()
-      elseif direction == "top" then
-        tmux.move_top()
-      end
+      require("tmux").move_to(direction)
     end,
     desc = "Move cursor to the " .. direction .. " window",
     mode = { "c", "n", "t", "v", "i" },
@@ -71,16 +24,7 @@ local function tmux_resize(direction, key, size)
   return {
     key,
     function()
-      local tmux = require("tmux")
-      if direction == "left" then
-        tmux.resize_left(size)
-      elseif direction == "right" then
-        tmux.resize_right(size)
-      elseif direction == "bottom" then
-        tmux.resize_bottom(size)
-      elseif direction == "top" then
-        tmux.resize_top(size)
-      end
+      require("tmux").resize_to(direction, size)
     end,
     desc = "Resize window to the " .. direction .. " by " .. size,
     mode = { "c", "n", "t", "v", "i" },
@@ -88,18 +32,18 @@ local function tmux_resize(direction, key, size)
 end
 
 M.keys = {
-  tmux_move("left", "<C-h>"),
-  tmux_move("right", "<C-l>"),
-  tmux_move("bottom", "<C-j>"),
-  tmux_move("top", "<C-k>"),
-  tmux_resize("left", "<A-x>h", 15),
-  tmux_resize("right", "<A-x>l", 15),
-  tmux_resize("bottom", "<A-x>j", 10),
-  tmux_resize("top", "<A-x>k", 10),
-  tmux_resize("left", "<A-x><S-h>", 1),
-  tmux_resize("right", "<A-x><S-l>", 1),
-  tmux_resize("bottom", "<A-x><S-j>", 1),
-  tmux_resize("top", "<A-x><S-k>", 1),
+  tmux_move("h", "<C-h>"),
+  tmux_move("l", "<C-l>"),
+  tmux_move("j", "<C-j>"),
+  tmux_move("k", "<C-k>"),
+  tmux_resize("h", "<A-x>h", 15),
+  tmux_resize("l", "<A-x>l", 15),
+  tmux_resize("j", "<A-x>j", 10),
+  tmux_resize("k", "<A-x>k", 10),
+  tmux_resize("h", "<A-x><S-h>", 1),
+  tmux_resize("l", "<A-x><S-l>", 1),
+  tmux_resize("j", "<A-x><S-j>", 1),
+  tmux_resize("k", "<A-x><S-k>", 1),
 }
 
 return M

--- a/nix/home-manager/programs/editors/neovim/config/lua/plugins/init.lua
+++ b/nix/home-manager/programs/editors/neovim/config/lua/plugins/init.lua
@@ -138,7 +138,6 @@ return {
   {
     "aserowy/tmux.nvim",
     event = "VeryLazy",
-    config = require("plugins.configs.tmux").config,
     opts = require("plugins.configs.tmux").opts,
     keys = require("plugins.configs.tmux").keys,
   },

--- a/nix/home-manager/programs/libs/libs.nix
+++ b/nix/home-manager/programs/libs/libs.nix
@@ -3,7 +3,7 @@
 # Libraries typically needed for neovim LSP to work correctly.
 {
   home.packages = with pkgs; [
-    boost
+    boost.dev
     fmt
   ];
 }

--- a/nix/home-manager/programs/shell/tmux.nix
+++ b/nix/home-manager/programs/shell/tmux.nix
@@ -71,7 +71,7 @@
             set -g @ukiyo-plugins "network-bandwidth disk-usage cpu-usage ram-usage ssh-session"
             set -g @ukiyo-show-powerline true
 
-            set -g @ukiyo-left-icon "#(date '+%d.%m.%y %R')"
+            set -g @ukiyo-left-icon "#(date '+%d.%m.%y %R (%a)')"
 
             set -g @ukiyo-network-bandwidth-download-label " "
             set -g @ukiyo-network-bandwidth-upload-label " "

--- a/nix/home-manager/programs/shell/tmux/tmux.conf
+++ b/nix/home-manager/programs/shell/tmux/tmux.conf
@@ -33,11 +33,11 @@ bind -r 'C-n' next-window
 bind -r 'C-p' previous-window
 
 %if "#{XDG_CONFIG_HOME}"
-  CONF_PATH="$XDG_CONFIG_HOME/tmux/tmux.conf"
+  TMUX_CONF_PATH="$XDG_CONFIG_HOME/tmux/tmux.conf"
 %else
-  CONF_PATH="$HOME/.config/tmux/tmux.conf"
+  TMUX_CONF_PATH="$HOME/.config/tmux/tmux.conf"
 %endif
-bind R source-file "$CONF_PATH"
+bind R source-file "$TMUX_CONF_PATH"
 
 # ---------------------- Smart pane switching -------------------- #
 # Default bindings: https://github.com/tmux/tmux/issues/729

--- a/nix/nixpkgs/overlays/vim-plugins.nix
+++ b/nix/nixpkgs/overlays/vim-plugins.nix
@@ -1,0 +1,26 @@
+{ inputs, ... }:
+final: prev:
+let
+  # Fix tmux.nvim interaction with snacks.
+  # https://github.com/folke/snacks.nvim/discussions/1802
+  # https://github.com/aserowy/tmux.nvim/issues/133
+
+  unstable = import inputs.nixpkgs_unstable { inherit (prev) system config; };
+in
+{
+  unstable = unstable // {
+    vimPlugins = unstable.vimPlugins // {
+      tmux-nvim = unstable.vimUtils.buildVimPlugin {
+        pname = "tmux.nvim";
+        version = "0-unstable-2026-04-09";
+        src = final.fetchFromGitHub {
+          owner = "rudenkornk";
+          repo = "tmux.nvim";
+          rev = "4aab248686d305f215530ffb428236faf4012f8f";
+          hash = "sha256-iyDqd0c6AwmCY52UHcnXY7WaLmp/ARWQ3Wdd/wPpaW4=";
+        };
+        meta.homepage = "https://github.com/rudenkornk/tmux.nvim";
+      };
+    };
+  };
+}


### PR DESCRIPTION
It plays with cmake better, though does not fully allow to build C++
projects without devshell
