### PR TITLE
dev volatile

### DIFF
--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -270,6 +270,10 @@
         module: /run/current-system/sw/lib/libtpm2_pkcs11.so
         critical: yes
       '';
+      # System-wide htop defaults. htop reads `/etc/htoprc` when a user has no
+      # `~/.config/htop/htoprc`. Regular users get their own via home-manager,
+      # so this covers root and any other config-less account.
+      "htoprc".source = ./home-manager/programs/system/configs/.config/htop/htoprc;
     };
   };
 

--- a/nix/home-manager/programs/ai/configs/.claude/keybindings.json
+++ b/nix/home-manager/programs/ai/configs/.claude/keybindings.json
@@ -22,7 +22,7 @@
         "ctrl+g": null,
         "cmd+k": "chat:clearScreen",
         "ctrl+x ctrl+k": "chat:killAgents",
-        "shift+tab": "chat:cycleMode",
+        "tab": "chat:cycleMode",
         "meta+p": "chat:modelPicker",
         "meta+o": "chat:fastMode",
         "meta+t": "chat:thinkingToggle",

--- a/nix/home-manager/programs/ai/configs/.claude/statusline.sh
+++ b/nix/home-manager/programs/ai/configs/.claude/statusline.sh
@@ -86,18 +86,47 @@ else
   duration="${minutes}m"
 fi
 
-# Prints `pct` as an integer percentage: green below `warn_at` percent, yellow below `crit_at`, red otherwise.
+# Prints `display_text` colored by `metric`: green below `warn_at`, yellow below `crit_at`, red otherwise.
 color_pct() {
-  local pct="$1" warn_at="$2" crit_at="$3"
-  local pct_int
-  pct_int=$(printf "%.0f" "$pct")
-  if [ "$pct_int" -lt "$warn_at" ]; then
-    printf "${GREEN}%s%%${RESET}" "$pct_int"
-  elif [ "$pct_int" -lt "$crit_at" ]; then
-    printf "${YELLOW}%s%%${RESET}" "$pct_int"
+  local display_text="$1" metric="$2" warn_at="$3" crit_at="$4"
+  local metric_int
+  metric_int=$(printf "%.0f" "$metric")
+  if [ "$metric_int" -lt "$warn_at" ]; then
+    printf "${GREEN}%s${RESET}" "$display_text"
+  elif [ "$metric_int" -lt "$crit_at" ]; then
+    printf "${YELLOW}%s${RESET}" "$display_text"
   else
-    printf "${RED}%s%%${RESET}" "$pct_int"
+    printf "${RED}%s${RESET}" "$display_text"
   fi
+}
+
+# Colors a rate-limit percentage by consumption speed.
+# I.e. "how much limits were credited from remaining time."
+# m = (used_frac - elapsed/period) / ((remaining+60s)/period);
+# m<=0 green, m<=0.30 yellow, else red.
+# The +60s prevents division by zero when remaining reaches 0 at the moment of reset.
+color_rate() {
+  local used_pct="$1" reset_epoch="$2" period_secs="$3"
+  local used_pct_int
+  used_pct_int=$(printf "%.0f" "$used_pct")
+  case "$reset_epoch" in
+  '' | *[!0-9]*)
+    printf "%s%%" "$used_pct_int"
+    return 0
+    ;;
+  esac
+  local m_pct
+  m_pct=$(awk -v used="$used_pct" -v reset="$reset_epoch" \
+    -v now="$now" -v period="$period_secs" '
+    BEGIN {
+      remaining = reset - now
+      if (remaining < 0) remaining = 0
+      elapsed = period - remaining
+      if (elapsed < 0) elapsed = 0
+      m = (used / 100 - elapsed / period) / ((remaining + 60) / period)
+      printf "%.0f", m * 100
+    }')
+  color_pct "${used_pct_int}%" "$m_pct" 0 30
 }
 
 # Context window.
@@ -112,7 +141,7 @@ fi
 
 if [ -n "$used_pct" ] && [ "$used_pct" != "0" ]; then
   ctx_k_used=$((total_input / 1000))
-  ctx_display="${ctx_k_used}k/${ctx_k}k $(color_pct "$used_pct" 50 80)"
+  ctx_display="${ctx_k_used}k/${ctx_k}k $(color_pct "${used_pct}%" "$used_pct" 50 80)"
 else
   ctx_display="0k/${ctx_k}k 0%"
 fi
@@ -150,12 +179,12 @@ if [ -n "$rate_5h" ] || [ -n "$rate_7d" ]; then
   part_5h=""
   part_7d=""
   if [ -n "$rate_5h" ]; then
-    part_5h="5h:$(color_pct "$rate_5h" 75 90)"
+    part_5h="5h:$(color_rate "$rate_5h" "$reset_5h" 18000)"
     left_5h=$(fmt_reset "$reset_5h")
     [ -n "$left_5h" ] && part_5h="${part_5h}${DIM} (${left_5h})${RESET}"
   fi
   if [ -n "$rate_7d" ]; then
-    part_7d="7d:$(color_pct "$rate_7d" 75 90)"
+    part_7d="7d:$(color_rate "$rate_7d" "$reset_7d" 604800)"
     left_7d=$(fmt_reset "$reset_7d")
     [ -n "$left_7d" ] && part_7d="${part_7d}${DIM} (${left_7d})${RESET}"
   fi

--- a/nix/home-manager/programs/shell/fzf.nix
+++ b/nix/home-manager/programs/shell/fzf.nix
@@ -237,7 +237,7 @@ let
   psHtopScript = pkgs.writeShellScript "fzf-ps-htop" ''
     set -euo pipefail
     pids="$(for line in "$@"; do ${psPidScript} "$line"; done | paste -sd,)"
-    ${lib.getExe pkgs.htop-vim} --pid "$pids"
+    sudo ${lib.getExe pkgs.htop-vim} --pid "$pids"
   '';
 
   psScript = pkgs.writeShellScript "fzf-ps" ''
@@ -252,7 +252,7 @@ let
       --bind "ctrl-r:transform:${psReloadTransform}" \
       --bind "enter:become(${psEnterScript} {+})" \
       --bind "ctrl-o:execute(${psHtopScript} {+})" \
-      --bind "ctrl-v:execute(${lib.getExe pkgs.htop-vim})" \
+      --bind "ctrl-v:execute(sudo ${lib.getExe pkgs.htop-vim})" \
       --bind "ctrl-t:execute(${psSignalScript} {})+transform:${psReloadTransform}" \
       --preview "${psPreview} {}" \
       --preview-window 'down,8,wrap,<1(down,8,wrap)' \

--- a/nix/home-manager/programs/shell/fzf.nix
+++ b/nix/home-manager/programs/shell/fzf.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ pkgs, lib, ... }:
 
 let
   ignoreFile = toString ./fzf/ignore;
@@ -10,7 +10,7 @@ let
 
   # ── ctrl-t: fd search ────────────────────────────────────────────────
 
-  fdCommon = "${pkgs.fd}/bin/fd --type file --follow --color always";
+  fdCommon = "${lib.getExe pkgs.fd} --type file --follow --color always";
   fd1 = "${fdCommon} --no-hidden --ignore --ignore-file ${ignoreFile}";
   fd2 = "${fdCommon} --hidden --ignore --ignore-file ${ignoreFile}";
   fd3 = "${fdCommon} --hidden --no-ignore --ignore-file ${ignoreFile}";
@@ -30,18 +30,18 @@ let
 
   fdPreview = pkgs.writeShellScript "fzf-fd-preview" ''
     set -euo pipefail
-    mime="$(${pkgs.file}/bin/file --mime-type -b -- "$1")"
+    mime="$(${lib.getExe pkgs.file} --mime-type -b -- "$1")"
     case "$mime" in
-      image/*) ${pkgs.kitty}/bin/kitty +kitten icat --transfer-mode=memory \
+      image/*) ${lib.getExe pkgs.kitty} +kitten icat --transfer-mode=memory \
         --stdin=no --place="$FZF_PREVIEW_COLUMNS"x"$FZF_PREVIEW_LINES""@0x0" -- "$1" ;;
-      *) ${pkgs.bat}/bin/bat --color=always --style=numbers --line-range :300 -- "$1" ;;
+      *) ${lib.getExe pkgs.bat} --color=always --style=numbers --line-range :300 -- "$1" ;;
     esac
   '';
 
   # ── ctrl-q: ripgrep search ────────────────────────────────────────────────
 
   rgCommon =
-    "${pkgs.ripgrep}/bin/rg "
+    "${lib.getExe pkgs.ripgrep} "
     + "--column "
     + "--line-number "
     + "--no-heading "
@@ -67,12 +67,12 @@ let
     esac
   '';
 
-  rgBatPreview = "${pkgs.bat}/bin/bat --color=always --style=numbers --highlight-line {2} {1}";
+  rgBatPreview = "${lib.getExe pkgs.bat} --color=always --style=numbers --highlight-line {2} {1}";
 
   rgScript = pkgs.writeShellScript "fzf-rg" ''
     set -euo pipefail
 
-    ${pkgs.fzf}/bin/fzf \
+    ${lib.getExe pkgs.fzf} \
       --disabled \
       --prompt='${h1}' \
       --bind "start:reload:${rg1} -- {q} || true" \
@@ -90,22 +90,22 @@ let
     # This sed relies on specific format enforced in current version of `fzf`.
     # `fzf` may change it in the future and this preview should be adjusted accordingly.
     echo "$@" | sed -E 's|[[:blank:]][0-9]+[[:blank:]]| >  |' \
-    | ${pkgs.bat}/bin/bat --language=bash --color=always --style=plain
+    | ${lib.getExe pkgs.bat} --language=bash --color=always --style=plain
   '';
 
   # ── ctrl-o: nix-search-tv ────────────────────────────────────────────────
 
-  nsBin = "${pkgs.nix-search-tv}/bin/nix-search-tv";
+  nsBin = "${lib.getExe pkgs.nix-search-tv}";
 
   nsScript = pkgs.writeShellScript "fzf-ns" ''
     set -euo pipefail
 
-    ${pkgs.fzf}/bin/fzf \
+    ${lib.getExe pkgs.fzf} \
       --prompt='  > ' \
       --scheme=history \
       --bind "start:reload:${nsBin} print" \
-      --bind "ctrl-v:execute-silent(${pkgs.xdg-utils}/bin/xdg-open \$(${nsBin} source {}) 2>/dev/null || true)" \
-      --bind "ctrl-o:execute-silent(${pkgs.xdg-utils}/bin/xdg-open \$(${nsBin} homepage {}) 2>/dev/null || true)" \
+      --bind "ctrl-v:execute-silent(${lib.getExe' pkgs.xdg-utils "xdg-open"} \$(${nsBin} source {}) 2>/dev/null || true)" \
+      --bind "ctrl-o:execute-silent(${lib.getExe' pkgs.xdg-utils "xdg-open"} \$(${nsBin} homepage {}) 2>/dev/null || true)" \
       --preview "${nsBin} preview {}"
   '';
 
@@ -114,10 +114,10 @@ let
   tldrScript = pkgs.writeShellScript "fzf-tldr" ''
     set -euo pipefail
 
-    ${pkgs.fzf}/bin/fzf \
+    ${lib.getExe pkgs.fzf} \
       --prompt='  > ' \
-      --bind "start:reload:${pkgs.tealdeer}/bin/tldr --list" \
-      --preview "${pkgs.tealdeer}/bin/tldr {} | ${pkgs.bat}/bin/bat --style=plain --color=always --language=markdown"
+      --bind "start:reload:${lib.getExe pkgs.tealdeer} --list" \
+      --preview "${lib.getExe pkgs.tealdeer} {} | ${lib.getExe pkgs.bat} --style=plain --color=always --language=markdown"
   '';
 
   # ── ctrl-x: process search ────────────────────────────────────────────────
@@ -127,7 +127,7 @@ let
   psAbsPathFilter = "sed -E 's| (/[^ ]*/)| |'";
   # --language=conf colors only several few lines for some reason.
   # --language=log works well, but is very slow.
-  psBat = "${pkgs.bat}/bin/bat --language=bat --color=always --style=plain";
+  psBat = "${lib.getExe pkgs.bat} --language=bat --color=always --style=plain";
   # `--ppid 2 -p 2 --deselect` filters out kernel processes.
   psCommon = "ps --ppid 2 -p 2 --deselect -o ${psFormat}";
 
@@ -218,7 +218,7 @@ let
       '30  SIGPWR      power failure' \
       '31  SIGSYS      bad system call')"
 
-    choice="$(printf '%s\n' "$signals" | ${pkgs.fzf}/bin/fzf --prompt="signal > pid $pid > " --no-multi)" || exit 0
+    choice="$(printf '%s\n' "$signals" | ${lib.getExe pkgs.fzf} --prompt="signal > pid $pid > " --no-multi)" || exit 0
     sig="$(printf '%s' "$choice" | awk '{print $1}')"
     kill "-$sig" "$pid"
   '';
@@ -231,13 +231,13 @@ let
     done
     for line in "$@"; do
       ${psPidScript} "$line"
-    done | ${pkgs.wl-clipboard}/bin/wl-copy --primary --trim-newline
+    done | ${lib.getExe' pkgs.wl-clipboard "wl-copy"} --primary --trim-newline
   '';
 
   psHtopScript = pkgs.writeShellScript "fzf-ps-htop" ''
     set -euo pipefail
     pids="$(for line in "$@"; do ${psPidScript} "$line"; done | paste -sd,)"
-    ${pkgs.htop-vim}/bin/htop --pid "$pids"
+    ${lib.getExe pkgs.htop-vim} --pid "$pids"
   '';
 
   psScript = pkgs.writeShellScript "fzf-ps" ''
@@ -252,7 +252,7 @@ let
       --bind "ctrl-r:transform:${psReloadTransform}" \
       --bind "enter:become(${psEnterScript} {+})" \
       --bind "ctrl-o:execute(${psHtopScript} {+})" \
-      --bind "ctrl-v:execute(${pkgs.htop-vim}/bin/htop)" \
+      --bind "ctrl-v:execute(${lib.getExe pkgs.htop-vim})" \
       --bind "ctrl-t:execute(${psSignalScript} {})+transform:${psReloadTransform}" \
       --preview "${psPreview} {}" \
       --preview-window 'down,8,wrap,<1(down,8,wrap)' \

--- a/nix/hosts/dellxps.nix
+++ b/nix/hosts/dellxps.nix
@@ -177,7 +177,7 @@
         serviceConfig = {
           Type = "oneshot";
           RemainAfterExit = true;
-          ExecStart = "${pkgs.alsa-utils}/bin/amixer -c sofhdadsp cset name='Bass Speaker Playback Switch' off,off";
+          ExecStart = "${lib.getExe' pkgs.alsa-utils "amixer"} -c sofhdadsp cset name='Bass Speaker Playback Switch' off,off";
         };
       };
     };


### PR DESCRIPTION
- **feat(ai): set claude models cycle to tab (similar to opencode)**
- **feat(ai): amend limit coloring for claude statusline**
- **refactor(nix): use lib.getExe for package binary paths**
- **feat(shell): run htop as root from fzf process view**
