### PR TITLE
dev volatile

### DIFF
--- a/nix/home-manager/programs/ai/ai.nix
+++ b/nix/home-manager/programs/ai/ai.nix
@@ -1,6 +1,13 @@
 { pkgs, config, ... }:
 
 # CLI AI tools.
+
+let
+  skills = {
+    ast-grep = "${pkgs.custom.ast-grep-skill}/share/skills/ast-grep";
+    playwright-cli = "${pkgs.custom.playwright-cli}/share/skills/playwright-cli";
+  };
+in
 {
   home.packages = with pkgs; [
     (locallib.with_secrets { pkg = aider-chat-full; })
@@ -32,10 +39,15 @@
       inherit (config) xdg;
       path = ./configs;
     })
-    // {
-      ".agents/skills/playwright-cli" = {
-        source = "${pkgs.custom.playwright-cli}/share/skills/playwright-cli";
+    # Claude Code and OpenCode read `~/.claude/skills`, Codex reads `~/.codex/skills`.
+    // (pkgs.lib.concatMapAttrs (name: source: {
+      ".claude/skills/${name}" = {
+        inherit source;
         recursive = true;
       };
-    };
+      ".codex/skills/${name}" = {
+        inherit source;
+        recursive = true;
+      };
+    }) skills);
 }

--- a/nix/home-manager/programs/ai/configs/.claude/settings.json
+++ b/nix/home-manager/programs/ai/configs/.claude/settings.json
@@ -66,6 +66,10 @@
           {
             "type": "command",
             "command": "tmux-agent-status set --state waiting"
+          },
+          {
+            "type": "command",
+            "command": "tmux-agent-name set --source title"
           }
         ]
       }
@@ -76,6 +80,10 @@
           {
             "type": "command",
             "command": "tmux-agent-status set --state done"
+          },
+          {
+            "type": "command",
+            "command": "tmux-agent-name set --source title"
           }
         ]
       }

--- a/nix/home-manager/programs/ai/configs/.claude/settings.json
+++ b/nix/home-manager/programs/ai/configs/.claude/settings.json
@@ -36,5 +36,69 @@
       "Read(~/.config/google-chrome/**)",
       "Edit(~/.config/google-chrome/**)"
     ]
+  },
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "tmux-agent-status set --state running"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "tmux-agent-status set --state running"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "permission_prompt|idle_prompt|elicitation_dialog|agent_needs_input",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "tmux-agent-status set --state waiting"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "tmux-agent-status set --state done"
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "tmux-agent-status set --state error"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "tmux-agent-status set --state clear"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/nix/home-manager/programs/ai/configs/.config/opencode/plugins/agent-status.ts
+++ b/nix/home-manager/programs/ai/configs/.config/opencode/plugins/agent-status.ts
@@ -1,0 +1,93 @@
+// opencode does not use the external hook model the other agents use; it runs
+// plugins in-process. The shell API ($) inherits opencode's environment, so
+// $TMUX_PANE is set and PATH includes tmux-agent-status (from home.packages).
+//
+// Lifecycle events arrive through the single generic `event` hook (the Hooks
+// interface has no per-event keys for these), discriminated by `event.type`.
+import type { Plugin } from "@opencode-ai/plugin";
+
+export const AgentStatus: Plugin = async ({ $ }) => {
+  // Each state update spawns a `tmux-agent-status` process, and opencode can emit two lifecycle
+  // events milliseconds apart (e.g. a final `busy` tick immediately followed by `session.idle`).
+  // Concurrently spawned processes finish in arbitrary order, so the earlier "running" write could
+  // land after the final "done" write and leave the tab stuck. A single-flight pump serializes the
+  // writes and coalesces to the newest requested state, so the last event always wins.
+  let pending: string | null = null;
+  let lastQueued: string | null = null;
+  let pumping = false;
+  const pump = async () => {
+    if (pumping) return;
+    pumping = true;
+    while (pending !== null) {
+      const state = pending;
+      pending = null;
+      try {
+        await $`tmux-agent-status set --state ${state}`;
+      } catch {
+        // tmux may be gone (detached pane, closed window); never break the event stream over it.
+      }
+    }
+    pumping = false;
+  };
+  const setState = (state: string) => {
+    if (state === lastQueued) return;
+    lastQueued = state;
+    pending = state;
+    void pump();
+  };
+
+  // `session.error` is immediately followed by a status flip to idle (see `halt()` in
+  // opencode's session processor), which would overwrite the error state with "done".
+  // Remember the error and let it survive that one idle; any new activity clears it.
+  let errored = false;
+
+  return {
+    event: async ({ event }) => {
+      // `question.*` events are runtime-only and absent from the SDK's typed
+      // Event union, so read the discriminant and payload through widened
+      // aliases instead of switching on the narrowed `event.type`.
+      const type = event.type as string;
+      const props = (event as { properties?: Record<string, unknown> })
+        .properties;
+
+      switch (type) {
+        case "session.status": {
+          const status = (props as { status?: { type?: string } } | undefined)
+            ?.status;
+          // While the agent is blocked on interactive input it stays quiet, so
+          // a busy tick only ever means real work — no waiting state to guard.
+          if (status?.type === "busy") {
+            errored = false;
+            setState("running");
+          }
+          break;
+        }
+        // The agent is blocked on interactive input: a question prompt
+        // (`question.asked`) or a tool-approval request (`permission.updated`).
+        case "question.asked":
+        case "permission.updated":
+          setState("waiting");
+          break;
+        case "question.replied":
+        case "permission.replied":
+          errored = false;
+          setState("running");
+          break;
+        case "session.idle":
+          // After a failure the session also goes idle; keep the error state visible.
+          if (!errored) setState("done");
+          break;
+        case "session.error": {
+          const name = (props as { error?: { name?: string } } | undefined)
+            ?.error?.name;
+          // A user interrupt (Esc) flows through the same event as a `MessageAbortedError`;
+          // that is not a failure, and the follow-up idle will render it as "done".
+          if (name === "MessageAbortedError") break;
+          errored = true;
+          setState("error");
+          break;
+        }
+      }
+    },
+  };
+};

--- a/nix/home-manager/programs/ai/configs/.config/opencode/plugins/agent-status.ts
+++ b/nix/home-manager/programs/ai/configs/.config/opencode/plugins/agent-status.ts
@@ -41,6 +41,11 @@ export const AgentStatus: Plugin = async ({ $ }) => {
   // Remember the error and let it survive that one idle; any new activity clears it.
   let errored = false;
 
+  // opencode AI-generates a session title (shown in its session list) and re-emits
+  // `session.updated` on every session change; forward the title as naming material
+  // only when it actually changed, so we do not spawn a process per event.
+  let lastTitle = "";
+
   return {
     event: async ({ event }) => {
       // `question.*` events are runtime-only and absent from the SDK's typed
@@ -85,6 +90,15 @@ export const AgentStatus: Plugin = async ({ $ }) => {
           if (name === "MessageAbortedError") break;
           errored = true;
           setState("error");
+          break;
+        }
+        case "session.updated": {
+          const title = (props as { info?: { title?: string } } | undefined)
+            ?.info?.title;
+          if (title && title !== lastTitle) {
+            lastTitle = title;
+            await $`tmux-agent-name set --source summary --text ${title}`;
+          }
           break;
         }
       }

--- a/nix/home-manager/programs/ai/configs/.config/opencode/tui.jsonc
+++ b/nix/home-manager/programs/ai/configs/.config/opencode/tui.jsonc
@@ -22,7 +22,7 @@
     // ctrl-s tmux reserved.
     // ctrl-t model variants.
     // ctrl-u (half) page up.
-    // ctrl-v paste.
+    // ctrl-v (half) page down (previously paste, remapped to match quirky claude mappings).
     // ctrl-w delete one word to the left.
     // ctrl-x leader key.
     // ctrl-y scroll up one line.
@@ -36,7 +36,7 @@
 
     "command_list": "ctrl+o",
     "messages_first": "home",
-    "messages_half_page_down": "ctrl+d",
+    "messages_half_page_down": "ctrl+d,ctrl+v",
     "messages_half_page_up": "ctrl+u",
     "messages_line_down": "ctrl+e",
     "messages_line_up": "ctrl+y",
@@ -53,6 +53,7 @@
     "input_move_down": "ctrl+n,down",
     "input_visual_line_end": "none",
     "input_line_end": "none",
+    "input_paste": "none",
 
     "input_newline": "return,shift+return",
     "input_submit": "ctrl+return",

--- a/nix/home-manager/programs/ai/configs/.gemini/settings.json
+++ b/nix/home-manager/programs/ai/configs/.gemini/settings.json
@@ -1,0 +1,45 @@
+{
+  "hooks": {
+    "BeforeModel": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "tmux-agent-status set --state running --emit-json"
+          }
+        ]
+      }
+    ],
+    "BeforeTool": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "tmux-agent-status set --state running --emit-json"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "tmux-agent-status set --state waiting --emit-json"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "tmux-agent-status set --state done --emit-json"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/nix/home-manager/programs/debuggers/debuggers.nix
+++ b/nix/home-manager/programs/debuggers/debuggers.nix
@@ -1,16 +1,40 @@
 { pkgs, ... }:
 
 # Debuggers.
-{
-  home.packages = with pkgs; [
-    creduce
-    gdb
-    lldb
-    netcoredbg
-    python3Packages.debugpy
-    valgrind
-    vscode-extensions.vadimcn.vscode-lldb
-    vscode-extensions.xdebug.php-debug
-    vscode-js-debug
+let
+  # `LazyVim`'s DAP language extras invoke these adapters by bare command name, since mason is disabled.
+  # The binaries ship inside the vscode extension packages under different names or paths,
+  # so expose each one under the name that `LazyVim` expects.
+  codelldb = pkgs.writeShellScriptBin "codelldb" ''
+    exec ${pkgs.vscode-extensions.vadimcn.vscode-lldb}/share/vscode/extensions/vadimcn.vscode-lldb/adapter/codelldb "$@"
+  '';
+  js-debug-adapter = pkgs.writeShellScriptBin "js-debug-adapter" ''
+    exec ${pkgs.vscode-js-debug}/bin/js-debug "$@"
+  '';
+  php-debug-adapter = pkgs.writeShellScriptBin "php-debug-adapter" ''
+    exec ${pkgs.nodejs}/bin/node \
+      ${pkgs.vscode-extensions.xdebug.php-debug}/share/vscode/extensions/xdebug.php-debug/out/phpDebug.js "$@"
+  '';
+  renamed-adapters = [
+    codelldb
+    js-debug-adapter
+    php-debug-adapter
   ];
+in
+{
+  home.packages =
+    with pkgs;
+    [
+      creduce
+      delve # Provides `dlv`, the Go debug adapter.
+      gdb
+      lldb
+      netcoredbg
+      python3Packages.debugpy
+      valgrind
+      vscode-extensions.vadimcn.vscode-lldb
+      vscode-extensions.xdebug.php-debug
+      vscode-js-debug
+    ]
+    ++ renamed-adapters;
 }

--- a/nix/home-manager/programs/desktop-envs/configs/.config/niri/config.kdl
+++ b/nix/home-manager/programs/desktop-envs/configs/.config/niri/config.kdl
@@ -94,6 +94,23 @@ binds {
     Ctrl+Alt+0 {
         spawn "noctalia-shell" "ipc" "call" "plugin:noctalia-calculator" "toggle"
     }
+    // M-hjkl only navigates niri windows and deliberately does not descend into tmux panes or nvim splits.
+    // Unifying it with the terminal's C-hjkl navigation was analyzed and rejected for the following reasons.
+    // Seamless tmux<->nvim hops rely on three primitives:
+    // 1. Keys forwarded down in-band (`send-keys` into the pane pty).
+    // 2. State inspected via IPC (nvim parses `display-message -p '#{window_layout}'` to detect a pane at the edge).
+    // 3. Actions driven via IPC (nvim runs `select-pane` over the tmux socket).
+    // There is no key ping-pong between the layers.
+    // Niri lacks the first two primitives at its hop: binds are global with no `if-shell` equivalent,
+    // and a Wayland compositor cannot forward a captured key to the focused client.
+    // Emulating this requires a `spawn-sh` script on every press
+    // (`niri msg` + `kitten @ send-key` with remote control),
+    // which costs 10-50ms of latency on all M-hjkl presses system-wide, races on key repeat,
+    // and dead keys in windows without a cooperating leaf app (plain shell, ssh without tmux, full-screen TUIs).
+    // A third bounce-up level would also be required:
+    // tmux at the edge must call `niri msg` via `#{pane_at_*}` flags,
+    // nvim needs a custom at-edge fallback (e.g. smart-splits.nvim `at_edge`),
+    // and `$NIRI_SOCKET` must be resolved dynamically, because the tmux server outlives niri sessions.
     Alt+H {
         focus-column-or-monitor-left
     }

--- a/nix/home-manager/programs/desktop-envs/configs/.config/niri/config.kdl
+++ b/nix/home-manager/programs/desktop-envs/configs/.config/niri/config.kdl
@@ -25,7 +25,6 @@ environment {
 }
 spawn-at-startup "noctalia-shell"
 spawn-at-startup "kitty"
-spawn-sh-at-startup "sleep 5 && noctalia-shell ipc call powerProfile enableNoctaliaPerformance"
 spawn-sh-at-startup "sleep 5 && noctalia-shell ipc call darkMode setLight"
 hotkey-overlay {
     skip-at-startup
@@ -87,6 +86,9 @@ binds {
     }
     Ctrl+Alt+B {
         spawn "noctalia-shell" "ipc" "call" "notifications" "toggleHistory"
+    }
+    Ctrl+Alt+G {
+        spawn "noctalia-shell" "ipc" "call" "notifications" "toggleDND"
     }
     Ctrl+Alt+Z {
         spawn "noctalia-shell" "ipc" "call" "calendar" "toggle"

--- a/nix/home-manager/programs/desktop-envs/configs/.config/niri/config.kdl
+++ b/nix/home-manager/programs/desktop-envs/configs/.config/niri/config.kdl
@@ -73,7 +73,7 @@ binds {
     Ctrl+Alt+F {
         spawn "noctalia-shell" "ipc" "call" "launcher" "toggle"
     }
-    Ctrl+Alt+Q {
+    Ctrl+Alt+V {
         spawn "noctalia-shell" "ipc" "call" "settings" "toggle"
     }
     Ctrl+Alt+C {
@@ -210,14 +210,11 @@ binds {
     Alt+Shift+Equal {
         set-window-height "+10%"
     }
-    Ctrl+Alt+G {
+    Ctrl+Alt+Q {
         toggle-window-floating
     }
-    Ctrl+Alt+V {
-        center-column
-    }
     Ctrl+Alt+R {
-        maximize-column
+        center-column
     }
     Ctrl+Alt+T {
         maximize-window-to-edges

--- a/nix/home-manager/programs/desktop-envs/mimeapps.nix
+++ b/nix/home-manager/programs/desktop-envs/mimeapps.nix
@@ -1,0 +1,58 @@
+_:
+
+# Default applications for `xdg-open` and GNOME's "Open With".
+{
+  xdg.mimeApps.enable = true;
+
+  xdg.mimeApps.defaultApplications =
+    let
+      browser = "firefox.desktop";
+      editor = "nvim.desktop";
+      video = "org.gnome.Showtime.desktop";
+      image = "org.gnome.Loupe.desktop";
+      audio = "org.gnome.Decibels.desktop";
+      pdf = "org.gnome.Papers.desktop";
+    in
+    {
+      "text/html" = browser;
+      "application/xhtml+xml" = browser;
+      "x-scheme-handler/http" = browser;
+      "x-scheme-handler/https" = browser;
+      "x-scheme-handler/about" = browser;
+      "x-scheme-handler/unknown" = browser;
+
+      "text/plain" = editor;
+      "application/json" = editor;
+
+      "video/mp4" = video;
+      "video/x-matroska" = video;
+      "video/webm" = video;
+      "video/quicktime" = video;
+      "video/x-msvideo" = video;
+      "video/mpeg" = video;
+      "video/ogg" = video;
+      "video/3gpp" = video;
+      "video/x-flv" = video;
+      "video/x-ms-wmv" = video;
+
+      "audio/mpeg" = audio;
+      "audio/flac" = audio;
+      "audio/mp4" = audio;
+      "audio/x-wav" = audio;
+      "audio/vnd.wave" = audio;
+      "audio/webm" = audio;
+      "audio/ogg" = audio;
+      "audio/aac" = audio;
+
+      "image/jpeg" = image;
+      "image/png" = image;
+      "image/gif" = image;
+      "image/webp" = image;
+      "image/svg+xml" = image;
+      "image/tiff" = image;
+      "image/bmp" = image;
+      "image/avif" = image;
+
+      "application/pdf" = pdf;
+    };
+}

--- a/nix/home-manager/programs/desktop-envs/noctalia/settings.json
+++ b/nix/home-manager/programs/desktop-envs/noctalia/settings.json
@@ -171,6 +171,28 @@
           "textColor": "none"
         },
         {
+          "compactMode": false,
+          "diskPath": "/persistent",
+          "iconColor": "none",
+          "id": "SystemMonitor",
+          "showCpuCores": false,
+          "showCpuFreq": false,
+          "showCpuTemp": false,
+          "showCpuUsage": true,
+          "showDiskAvailable": false,
+          "showDiskUsage": true,
+          "showDiskUsageAsPercent": false,
+          "showGpuTemp": false,
+          "showLoadAverage": false,
+          "showMemoryAsPercent": false,
+          "showMemoryUsage": true,
+          "showNetworkStats": true,
+          "showSwapUsage": false,
+          "textColor": "none",
+          "useMonospaceFont": true,
+          "usePadding": true
+        },
+        {
           "applyToAllMonitors": false,
           "displayMode": "alwaysShow",
           "iconColor": "none",

--- a/nix/home-manager/programs/desktop-envs/noctalia/settings.json
+++ b/nix/home-manager/programs/desktop-envs/noctalia/settings.json
@@ -367,7 +367,7 @@
   "general": {
     "allowPanelsOnScreenWithoutBar": true,
     "allowPasswordWithFprintd": true,
-    "animationDisabled": false,
+    "animationDisabled": true,
     "animationSpeed": 2,
     "autoStartAuth": false,
     "avatarImage": "~/.face",

--- a/nix/home-manager/programs/fs-navigation/fs-navigation.nix
+++ b/nix/home-manager/programs/fs-navigation/fs-navigation.nix
@@ -3,6 +3,7 @@
 # File management & search tools.
 {
   home.packages = with pkgs; [
+    ast-grep # Structural search-and-replace backend for grug-far.
     bat
     dua
     dust

--- a/nix/home-manager/programs/linters/linters.nix
+++ b/nix/home-manager/programs/linters/linters.nix
@@ -13,13 +13,11 @@
     cmake-lint
     cpplint
     eslint
-    fourmolu
     ghalint
     gitleaks
     gitlint
     gofumpt
     golangci-lint
-    haskellPackages.cabal-fmt
     isort
     kdlfmt
     ktlint

--- a/nix/home-manager/programs/lsp/lsp.nix
+++ b/nix/home-manager/programs/lsp/lsp.nix
@@ -11,6 +11,7 @@
     dockerfile-language-server
     gitlab-ci-ls
     gopls
+    haskell-language-server
     helm-ls
     kotlin-language-server
     lua-language-server

--- a/nix/home-manager/programs/lsp/lsp.nix
+++ b/nix/home-manager/programs/lsp/lsp.nix
@@ -11,7 +11,6 @@
     dockerfile-language-server
     gitlab-ci-ls
     gopls
-    haskell-language-server
     helm-ls
     kotlin-language-server
     lua-language-server

--- a/nix/home-manager/programs/lsp/lsp.nix
+++ b/nix/home-manager/programs/lsp/lsp.nix
@@ -4,6 +4,7 @@
 {
   home.packages = with pkgs; [
     angular-language-server
+    ansible-language-server
     astro-language-server
     bash-language-server
     docker-compose-language-service
@@ -31,7 +32,6 @@
     vscode-extensions.elixir-lsp.vscode-elixir-ls
     vscode-extensions.gleam.gleam
     vscode-extensions.mathiasfrohlich.kotlin
-    vscode-extensions.redhat.ansible
     vscode-js-debug
     vscode-langservers-extracted
     vtsls

--- a/nix/home-manager/programs/shell/tmux.nix
+++ b/nix/home-manager/programs/shell/tmux.nix
@@ -72,10 +72,10 @@
             set -g pane-active-border-style fg=#80f0ff,bg=#1a1b26
 
 
-            set -g @ukiyo-plugins "network-bandwidth cpu-usage ram-usage custom:${./tmux/custom.sh} ssh-session"
+            set -g @ukiyo-plugins "ssh-session"
             set -g @ukiyo-show-powerline true
 
-            set -g @ukiyo-left-icon "#(date '+%d.%m.%y %R (%a)')"
+            set -g @ukiyo-left-icon "session"
 
             set -g @ukiyo-custom-plugin-colors "info bg_pane"
 

--- a/nix/home-manager/programs/shell/tmux.nix
+++ b/nix/home-manager/programs/shell/tmux.nix
@@ -100,6 +100,10 @@
     ];
   };
 
+  home = {
+    packages = [ pkgs.custom.tmux-agent-status ];
+  };
+
   xdg = {
     configFile = {
       "tmux/toggle_pane.py".source = ./tmux/toggle_pane.py;

--- a/nix/home-manager/programs/shell/tmux/custom.sh
+++ b/nix/home-manager/programs/shell/tmux/custom.sh
@@ -21,8 +21,14 @@ display_keyboard_layout() {
 }
 
 main() {
-  echo -n "  "
-  df /home --block-size G | awk 'NR==2 {printf "%.1fTiB/%.1fTiB  ", $3 / 1024, $2 / 1024}'
+  short=false
+
+  echo -n " "
+  if [ "$short" = true ]; then
+    df /home --block-size G | awk 'NR==2 {printf "%.1fT", $3 / 1024}'
+  else
+    df /home --block-size G | awk 'NR==2 {printf "%.1fTiB/%.1fTiB  ", $3 / 1024, $2 / 1024}'
+  fi
 
   # display_keyboard_layout
 

--- a/nix/home-manager/programs/shell/tmux/tmux.conf
+++ b/nix/home-manager/programs/shell/tmux/tmux.conf
@@ -103,3 +103,7 @@ bind -r "J" if-shell "$is_vim" 'send-keys M-z J' 'resize-pane -D 1'
 bind -r "K" if-shell "$is_vim" 'send-keys M-z K' 'resize-pane -U 1'
 
 bind "C-g" run-shell '${XDG_CONFIG_HOME:-$HOME/.config}/tmux/toggle_pane.py toggle'
+
+
+# ------------------- Tab names customization ---------------- #
+run-shell "tmux-agent-install-format"

--- a/nix/home-manager/programs/shell/tmux/tmux.conf
+++ b/nix/home-manager/programs/shell/tmux/tmux.conf
@@ -12,7 +12,11 @@ set -g cursor-style bar
 # Forward CSI-u extended keys from the outer terminal to inner apps,
 # so they can tell Ctrl+Enter / Shift+Enter apart from plain Enter (submit).
 # Note that this also may require additional support from terminal side (see kitty.conf).
-set -s extended-keys always
+# Use `on` and not `always`: apps that care (Claude Code, opencode, neovim) request extended keys themselves,
+# and `always` force-encodes unsolicited terminal replies (e.g. kitty's answers to snacks.nvim image queries
+# sent via passthrough), which makes them leak into neovim as literal text.
+# See https://github.com/folke/snacks.nvim/issues/2332
+set -s extended-keys on
 set -as terminal-features 'xterm-kitty:extkeys'
 
 

--- a/nix/home-manager/programs/shell/tmux/tmux.conf
+++ b/nix/home-manager/programs/shell/tmux/tmux.conf
@@ -57,6 +57,9 @@ bind R source-file "$TMUX_CONF_PATH"
 # See: https://github.com/christoomey/vim-tmux-navigator
 # See: https://github.com/numToStr/Navigator.nvim
 # Note: tmux-pain-control breaks these mappings!
+#
+# C-hjkl deliberately stays separate from niri's M-hjkl window navigation.
+# Unification was analyzed and rejected; see the navigation binds in niri's config.kdl for the reasoning.
 is_vim="ps -o state= -o comm= -t '#{pane_tty}' \
     | grep -iqE '^[^TXZ ]+ +(\\S+\\/)?g?(view|nvim?x?)(diff)?$'"
 # TODO: remove `crush` from this condition, once keybindings customization is supported in crush.

--- a/nix/home-manager/programs/text-editors/neovim.nix
+++ b/nix/home-manager/programs/text-editors/neovim.nix
@@ -94,7 +94,11 @@
       in
       {
         "nvim/site/parser".source = "${treesitterGrammars}/parser/";
-        "nvim/site/queries".source = "${treesitterGrammars}/queries/";
+        # Queries come from the plugin, not the grammar derivations. The latter omit the
+        # inheritance-only base modules (`ecma`, `jsx`, `html_tags`), so every language whose
+        # query does `; inherits: ecma` (javascript, typescript, tsx, vue, svelte, ...) fails to load.
+        # The plugin ships the complete curated set; it is identical to the grammar queries otherwise.
+        "nvim/site/queries".source = "${pkgs.unstable.vimPlugins.nvim-treesitter}/runtime/queries/";
         "nvim/site/spell".source = "${pkgs.custom.vim-spell}/spell/";
 
         # Workaround for missing mason packages in neovim.

--- a/nix/home-manager/programs/text-editors/neovim.nix
+++ b/nix/home-manager/programs/text-editors/neovim.nix
@@ -8,6 +8,7 @@
       enable = true;
       defaultEditor = true;
       withNodeJs = true;
+      withPerl = true;
       withPython3 = true;
       withRuby = true;
 
@@ -59,27 +60,16 @@
           sympy
         ];
 
-      extraPackages =
-        (with pkgs.perlPackages; [
-          Appcpanminus
-          ArchiveTar
-          FileHomeDir
-          Graph
-          LogLog4perl
-          NeovimExt
-          UnicodeString
-          YAMLTiny
-        ])
-
-        # Other tools.
-        ++ (with pkgs; [
-          ghostscript
-          imagemagick
-          lua51Packages.luarocks
-          tree-sitter
-          virtualenv
-          websocat # For typst.
-        ]);
+      # The perl provider is wired up by `withPerl` above, which builds its own perl env
+      # with `Neovim::Ext`. No perl packages are needed here.
+      extraPackages = with pkgs; [
+        ghostscript
+        imagemagick
+        lua51Packages.luarocks
+        tree-sitter
+        virtualenv
+        websocat # For typst.
+      ];
     };
   };
 

--- a/nix/home-manager/programs/text-editors/neovim.nix
+++ b/nix/home-manager/programs/text-editors/neovim.nix
@@ -11,6 +11,13 @@
       withPython3 = true;
       withRuby = true;
 
+      # We manage `init.lua` ourselves via the recursive `xdg.configFile."nvim"` below.
+      # Without this, our `config/init.lua` clobbers the one home-manager generates,
+      # which carries the `extraLuaPackages` `package.path`/`cpath` bootstrap and the provider host vars,
+      # so `require("jsregexp")` and the Node provider break.
+      # With this set, home-manager loads that bootstrap through a wrapper `--cmd` instead.
+      sideloadInitLua = true;
+
       plugins = [ pkgs.unstable.vimPlugins.lazy-nvim ]; # Only lazy-nvim itself is loaded as a Neovim plugin.
 
       extraWrapperArgs = [

--- a/nix/home-manager/programs/text-editors/neovim.nix
+++ b/nix/home-manager/programs/text-editors/neovim.nix
@@ -83,6 +83,11 @@
 
       "nvim/lua/config/nix_managed_plugins.lua".text = # Comment preventing fold.
         ''return "${import ./neovim/plugins.nix { inherit pkgs; }}"'';
+
+      # `snacks.picker` loads sqlite3 through luajit ffi. There is no global library path on NixOS,
+      # so we hand it the absolute path to `libsqlite3.so`. Otherwise it falls back to file storage.
+      "nvim/lua/config/nix_sqlite.lua".text = # Comment preventing fold.
+        ''return "${pkgs.sqlite.out}/lib/libsqlite3.so"'';
     };
 
     dataFile =

--- a/nix/home-manager/programs/text-editors/neovim.nix
+++ b/nix/home-manager/programs/text-editors/neovim.nix
@@ -119,6 +119,7 @@
 
   home = {
     packages = with pkgs; [
+      inotify-tools # Faster LSP file watching than the libuv fallback.
       sqlite
       vim
       wl-clipboard

--- a/nix/home-manager/programs/text-editors/neovim.nix
+++ b/nix/home-manager/programs/text-editors/neovim.nix
@@ -109,7 +109,7 @@
         "nvim/mason/packages/svelte-language-server/node_modules/typescript-svelte-plugin".source =
           "${pkgs.svelte-language-server}/lib/node_modules/svelte-language-server/packages/typescript-plugin/";
         "nvim/mason/packages/js-debug-adapter/js-debug/src/dapDebugServer.js".source =
-          "${pkgs.vscode-js-debug}/lib/node_modules/js-debug/src/dapDebugServer.ts";
+          "${pkgs.vscode-js-debug}/lib/node_modules/js-debug/dist/src/dapDebugServer.js";
         "nvim/mason/packages/vue-language-server/node_modules/@vue/language-server".source =
           "${pkgs.vue-language-server}/lib/language-tools/packages/language-server";
       };

--- a/nix/home-manager/programs/text-editors/neovim/config/lazyvim.json
+++ b/nix/home-manager/programs/text-editors/neovim/config/lazyvim.json
@@ -34,7 +34,6 @@
     "lazyvim.plugins.extras.lang.git",
     "lazyvim.plugins.extras.lang.gleam",
     "lazyvim.plugins.extras.lang.go",
-    "lazyvim.plugins.extras.lang.haskell",
     "lazyvim.plugins.extras.lang.helm",
     "lazyvim.plugins.extras.lang.java",
     "lazyvim.plugins.extras.lang.json",

--- a/nix/home-manager/programs/text-editors/neovim/config/lua/plugins/configs/blink.lua
+++ b/nix/home-manager/programs/text-editors/neovim/config/lua/plugins/configs/blink.lua
@@ -2,9 +2,9 @@ local M = {}
 
 local kind_icons = {
   claude = " ",
-  openai = " ",
+  openai = " ",
   codestral = "󰬔 ",
-  gemini = " ",
+  gemini = " ",
   Groq = "",
   Openrouter = "󱂇 ",
   Ollama = "󰳆 ",

--- a/nix/home-manager/programs/text-editors/neovim/config/lua/plugins/configs/sidekick.lua
+++ b/nix/home-manager/programs/text-editors/neovim/config/lua/plugins/configs/sidekick.lua
@@ -1,5 +1,14 @@
 local M = {}
 
+-- Disable next edit suggestions. They need the `copilot-language-server`, which we do not install,
+-- and we rely on `minuet-ai` and the AI CLI tools instead.
+-- With `nes.enabled = false`, `LazyVim`'s `ai.sidekick` extra also stops registering the copilot LSP.
+M.opts = {
+  nes = {
+    enabled = false,
+  },
+}
+
 M.keys = {
   {
     "<leader>aa",

--- a/nix/home-manager/programs/text-editors/neovim/config/lua/plugins/configs/snacks.lua
+++ b/nix/home-manager/programs/text-editors/neovim/config/lua/plugins/configs/snacks.lua
@@ -18,6 +18,10 @@ end
 M.opts = {
   picker = {
     hidden = true,
+    db = {
+      -- Absolute path to `libsqlite3.so`, injected by nix. Enables sqlite-backed frecency and history.
+      sqlite3_path = require("config.nix_sqlite"),
+    },
     sources = {
       explorer = {
         ignored = true,

--- a/nix/home-manager/programs/text-editors/neovim/config/lua/plugins/init.lua
+++ b/nix/home-manager/programs/text-editors/neovim/config/lua/plugins/init.lua
@@ -104,6 +104,7 @@ return {
   {
     "folke/sidekick.nvim", -- ai.sidekick
     keys = require("plugins.configs.sidekick").keys,
+    opts = require("plugins.configs.sidekick").opts,
   },
   {
     "ggandor/flit.nvim", -- editor.leap

--- a/nix/home-manager/programs/text-editors/neovim/plugins.nix
+++ b/nix/home-manager/programs/text-editors/neovim/plugins.nix
@@ -28,8 +28,6 @@ let
     gitsigns-nvim
     grug-far-nvim
     gruvbox-nvim
-    haskell-snippets-nvim
-    haskell-tools-nvim
     helm-ls-nvim
     inc-rename-nvim
     iron-nvim
@@ -62,7 +60,6 @@ let
     neotest-go
     neotest-golang
     neotest-gtest
-    neotest-haskell
     neotest-pest
     neotest-phpunit
     neotest-python

--- a/nix/home-manager/programs/toolchains/toolchains.nix
+++ b/nix/home-manager/programs/toolchains/toolchains.nix
@@ -9,6 +9,7 @@
     gleam
     go
     jq
+    lean4
     lua5_4
     molecule
     nodejs

--- a/nix/home-manager/programs/toolchains/toolchains.nix
+++ b/nix/home-manager/programs/toolchains/toolchains.nix
@@ -4,10 +4,14 @@
 {
   home.packages = with pkgs; [
     ansible
+    cabal-install
     dart
     dotnet-sdk
+    ghc
     gleam
     go
+    haskellPackages.fast-tags
+    haskellPackages.hoogle
     jq
     lean4
     lua5_4

--- a/nix/home-manager/programs/toolchains/toolchains.nix
+++ b/nix/home-manager/programs/toolchains/toolchains.nix
@@ -4,14 +4,10 @@
 {
   home.packages = with pkgs; [
     ansible
-    cabal-install
     dart
     dotnet-sdk
-    ghc
     gleam
     go
-    haskellPackages.fast-tags
-    haskellPackages.hoogle
     jq
     lean4
     lua5_4

--- a/nix/home-manager/programs/vcs/configs/.config/arc/config
+++ b/nix/home-manager/programs/vcs/configs/.config/arc/config
@@ -4,12 +4,12 @@
   br = branch -vv
   ck = checkout
   cm = commit
-  cma = commit --all --message 'a' # Commit all.
+  cma = commit --all --message a # Commit all.
   cmd = commit --amend
   cmm = commit --amend
-  cms = commit --message 's' # Commit staged.
+  cms = commit --message s # Commit staged.
   cp = cherry-pick
-  df = diff
+  df = diff --relative=.
   ft = fetch
   l = log
   lg = log --graph
@@ -22,6 +22,6 @@
   rb = rebase
   rbi = rebase --interactive HEAD~26
   rh = reset --hard
-  sg = diff --staged
+  sg = diff --staged --relative=.
   sh = show
   st = status

--- a/nix/nixpkgs/overlays/custom.nix
+++ b/nix/nixpkgs/overlays/custom.nix
@@ -39,5 +39,38 @@ _: final: prev: {
     playwright-cli = import ./custom/playwright-cli.nix final prev;
 
     vim-spell = import ./custom/vim-spell.nix final prev;
+
+    tmux-agent-status =
+      let
+        runtimeInputs = [
+          final.gawk
+          final.procps
+          final.tmux
+          final.uutils-coreutils-noprefix
+        ];
+        tmux-agent-label = final.writeShellApplication {
+          name = "tmux-agent-label";
+          inherit runtimeInputs;
+          text = builtins.readFile ./custom/tmux-agent-status/tmux-agent-label.sh;
+        };
+        tmux-agent-status = final.writeShellApplication {
+          name = "tmux-agent-status";
+          inherit runtimeInputs;
+          text = builtins.readFile ./custom/tmux-agent-status/tmux-agent-status.sh;
+        };
+        tmux-agent-install-format = final.writeShellApplication {
+          name = "tmux-agent-install-format";
+          inherit runtimeInputs;
+          text = builtins.readFile ./custom/tmux-agent-status/tmux-agent-install-format.sh;
+        };
+      in
+      final.symlinkJoin {
+        name = "tmux-agent-status";
+        paths = [
+          tmux-agent-label
+          tmux-agent-status
+          tmux-agent-install-format
+        ];
+      };
   };
 }

--- a/nix/nixpkgs/overlays/custom.nix
+++ b/nix/nixpkgs/overlays/custom.nix
@@ -48,6 +48,8 @@ _: final: prev: {
           final.gnugrep
           final.gnused
           final.jq
+          final.libnotify
+          final.niri
           final.procps
           final.tmux
           final.uutils-coreutils-noprefix

--- a/nix/nixpkgs/overlays/custom.nix
+++ b/nix/nixpkgs/overlays/custom.nix
@@ -67,13 +67,10 @@ _: final: prev: {
           inherit runtimeInputs;
           text = builtins.readFile ./custom/tmux-agent-status/tmux-agent-install-format.sh;
         };
-        # Wrapped with `with_secrets` to access API keys for AI agent calls.
-        tmux-agent-name = final.locallib.with_secrets {
-          pkg = final.writeShellApplication {
-            name = "tmux-agent-name";
-            inherit runtimeInputs;
-            text = builtins.readFile ./custom/tmux-agent-status/tmux-agent-name.sh;
-          };
+        tmux-agent-name = final.writeShellApplication {
+          name = "tmux-agent-name";
+          inherit runtimeInputs;
+          text = builtins.readFile ./custom/tmux-agent-status/tmux-agent-name.sh;
         };
       in
       final.symlinkJoin {

--- a/nix/nixpkgs/overlays/custom.nix
+++ b/nix/nixpkgs/overlays/custom.nix
@@ -43,7 +43,11 @@ _: final: prev: {
     tmux-agent-status =
       let
         runtimeInputs = [
+          final.curl
           final.gawk
+          final.gnugrep
+          final.gnused
+          final.jq
           final.procps
           final.tmux
           final.uutils-coreutils-noprefix
@@ -63,6 +67,14 @@ _: final: prev: {
           inherit runtimeInputs;
           text = builtins.readFile ./custom/tmux-agent-status/tmux-agent-install-format.sh;
         };
+        # Wrapped with `with_secrets` to access API keys for AI agent calls.
+        tmux-agent-name = final.locallib.with_secrets {
+          pkg = final.writeShellApplication {
+            name = "tmux-agent-name";
+            inherit runtimeInputs;
+            text = builtins.readFile ./custom/tmux-agent-status/tmux-agent-name.sh;
+          };
+        };
       in
       final.symlinkJoin {
         name = "tmux-agent-status";
@@ -70,6 +82,7 @@ _: final: prev: {
           tmux-agent-label
           tmux-agent-status
           tmux-agent-install-format
+          tmux-agent-name
         ];
       };
   };

--- a/nix/nixpkgs/overlays/custom.nix
+++ b/nix/nixpkgs/overlays/custom.nix
@@ -34,6 +34,8 @@ _: final: prev: {
           (builtins.readFile ./custom/sing-box-run.sh);
     };
 
+    ast-grep-skill = import ./custom/ast-grep-skill.nix final prev;
+
     playwright-cli = import ./custom/playwright-cli.nix final prev;
 
     vim-spell = import ./custom/vim-spell.nix final prev;

--- a/nix/nixpkgs/overlays/custom/ast-grep-skill.nix
+++ b/nix/nixpkgs/overlays/custom/ast-grep-skill.nix
@@ -1,0 +1,38 @@
+final: _prev:
+
+# The official `ast-grep` agent skill, maintained by the ast-grep org.
+# It is not shipped inside the `ast-grep` package itself (that only carries shell completions),
+# so we vendor it from GitHub and expose it under `share/skills`, mirroring `playwright-cli`.
+# Only the `ast-grep` search skill is installed; the repo's `outline` skill relies on an
+# `ast-grep outline` subcommand that does not exist in our pinned ast-grep, so it is left out.
+
+final.stdenvNoCC.mkDerivation {
+  pname = "ast-grep-skill";
+  version = "0-unstable-2026-07-03";
+
+  src = final.fetchFromGitHub {
+    owner = "ast-grep";
+    repo = "agent-skill";
+    rev = "c2a9bc154f4ffe08b25d28d5e852dfac8c0d0d8a";
+    hash = "sha256-awochSE2OupbsmaGx0xc7wHf0ovVMSdtHv4gZAGWOus=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/share/skills
+    cp -r ast-grep/skills/ast-grep $out/share/skills/ast-grep
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Official ast-grep agent skill for structural code search and analysis";
+    homepage = "https://github.com/ast-grep/agent-skill";
+    # Upstream ships no license file, so default copyright applies; vendored for personal use only.
+    # Left commented out so the skill is not gated behind the unfree allowlist.
+    # license = final.lib.licenses.unfree;
+    platforms = final.lib.platforms.all;
+  };
+}

--- a/nix/nixpkgs/overlays/custom/tmux-agent-status/tmux-agent-install-format.sh
+++ b/nix/nixpkgs/overlays/custom/tmux-agent-status/tmux-agent-install-format.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Theme-agnostic installer for the agent tab-bar label.
+#
+# Run it AFTER the theme has been loaded, e.g. from tmux.conf:
+#   run-shell "tmux-agent-install-format"
+set -euo pipefail
+
+LABEL="#(tmux-agent-label #{window_id})"
+
+# Literal (non-regex) first-occurrence replace. ENVIRON avoids awk -v's
+# backslash processing, so format strings pass through untouched.
+litreplace() {
+  S="$1" F="$2" R="$3" awk 'BEGIN {
+    s = ENVIRON["S"]; f = ENVIRON["F"]; r = ENVIRON["R"]
+    i = index(s, f)
+    if (i) printf "%s", substr(s, 1, i - 1) r substr(s, i + length(f))
+    else printf "%s", s
+  }'
+}
+
+inject() {
+  local opt="$1" out
+  out="$(tmux show-option -gqv "$opt" 2>/dev/null || true)"
+  [ -n "$out" ] || return 0
+
+  # Remove our own fragment if a previous run added it, so we re-splice exactly
+  # one copy instead of stacking duplicates on every reload.
+  out="$(litreplace "$out" "$LABEL" "")"
+
+  # Splice the label right after the window name #W (or #{window_name}).
+  if [[ "$out" == *'#W'* ]]; then
+    out="$(litreplace "$out" '#W' "#W${LABEL}")"
+  elif [[ "$out" == *'#{window_name}'* ]]; then
+    out="$(litreplace "$out" '#{window_name}' "#{window_name}${LABEL}")"
+  else
+    out="${out}${LABEL}"
+  fi
+
+  tmux set-option -g "$opt" "$out"
+}
+
+# No server / not in tmux: nothing to do.
+tmux has-session 2>/dev/null || exit 0
+
+inject window-status-format
+inject window-status-current-format

--- a/nix/nixpkgs/overlays/custom/tmux-agent-status/tmux-agent-label.sh
+++ b/nix/nixpkgs/overlays/custom/tmux-agent-status/tmux-agent-label.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# The single tab-bar fragment: emits a window's agent icon + status icon.
+# Invoked from tmux as: #(tmux-agent-label #{window_id})
+set -euo pipefail
+
+win="${1:-}"
+[ -n "$win" ] || exit 0
+
+match_agent() {
+  case "$1" in
+  *cursor-agent*) printf '#[fg=#dadada] #[fg=default]' ;;
+  *claude*) printf '#[fg=#d97757] #[fg=default]' ;;
+  *codex*) printf '#[fg=#10a37f] #[fg=default]' ;;
+  *gemini*) printf '#[fg=#4796e3] #[fg=default]' ;;
+  *opencode*) printf '#[fg=#9aa5ce]󱞟 #[fg=default]' ;;
+  *) : ;;
+  esac
+}
+
+# The second argument is the agent's own icon color, so a running agent's
+# status glyph matches the color of its identity icon.
+render_status() {
+  local color="${2:-default}"
+  case "$1" in
+  running) printf '#[fg=%s]#[fg=default]' "$color" ;;
+  waiting) printf '#[fg=#f5680a]⏸ #[fg=default]' ;;
+  done) printf '#[fg=#9ece6a]󰸞 #[fg=default]' ;;
+  error) printf '#[fg=#db4b4b] #[fg=default]' ;;
+  *) : ;;
+  esac
+}
+
+# Print the command lines of the process subtree rooted at $1 (inclusive),
+# found via a breadth-first walk over a single ps snapshot.
+subtree_args() {
+  local root="$1" snap pids frontier next kids k
+  [ -n "$root" ] || return 0
+  snap="$(ps -eo pid=,ppid=,args= 2>/dev/null || true)"
+  [ -n "$snap" ] || return 0
+
+  pids=" $root "
+  frontier="$root"
+  while [ -n "$frontier" ]; do
+    next=""
+    kids="$(printf '%s\n' "$snap" | awk -v set=" $frontier " '$2 && index(set, " " $2 " ") {print $1}')"
+    for k in $kids; do
+      case "$pids" in
+      *" $k "*) : ;;
+      *)
+        pids="$pids$k "
+        next="$next $k"
+        ;;
+      esac
+    done
+    frontier="$next"
+  done
+
+  printf '%s\n' "$snap" | awk -v ids="$pids" 'index(ids, " " $1 " ") { $1=""; $2=""; print }'
+}
+
+# Identity glyph for a whole window: first agent found across any of its panes.
+# Keying on the window (not the active pane) shows the icon regardless of focus.
+detect_window() {
+  local w="$1" pid out
+  while read -r pid; do
+    [ -n "$pid" ] || continue
+    out="$(match_agent "$(subtree_args "$pid")")"
+    if [ -n "$out" ]; then
+      printf '%s' "$out"
+      return 0
+    fi
+  done < <(tmux list-panes -t "$w" -F '#{pane_pid}' 2>/dev/null || true)
+}
+
+icon="$(detect_window "$win")"
+status="$(tmux show-option -wqv -t "$win" @agent_status 2>/dev/null || true)"
+
+# No agent -> no label at all. Also drop a leftover status, so an agent
+# started later in this window does not inherit its predecessor's state.
+if [ -z "$icon" ]; then
+  [ -z "$status" ] || tmux set-option -wu -t "$win" @agent_status 2>/dev/null || true
+  exit 0
+fi
+
+# The agent icon carries its brand color as a leading `#[fg=#rrggbb]`; extract it
+# so the running status glyph can be tinted to match.
+agent_color="${icon#*fg=}"
+agent_color="${agent_color%%]*}"
+
+# Leading space separates the label from the window name.
+status_out="$(render_status "$status" "$agent_color")"
+if [ -n "$status_out" ]; then
+  printf ' %s%s' "$icon" "$status_out"
+else
+  printf ' %s' "$icon"
+fi

--- a/nix/nixpkgs/overlays/custom/tmux-agent-status/tmux-agent-label.sh
+++ b/nix/nixpkgs/overlays/custom/tmux-agent-status/tmux-agent-label.sh
@@ -85,10 +85,8 @@ if [ -z "$icon" ]; then
   # `<automatic>` sentinel, which must match tmux-agent-name) and drop all naming state.
   user_name="$(tmux show-option -wqv -t "$win" @agent_name_user 2>/dev/null || true)"
   if [ -n "$user_name" ]; then
-    tmux set-option -wu -t "$win" @agent_named 2>/dev/null || true
     tmux set-option -wu -t "$win" @agent_name_material 2>/dev/null || true
     tmux set-option -wu -t "$win" @agent_name_refresh 2>/dev/null || true
-    tmux set-option -wu -t "$win" @agent_name_tries 2>/dev/null || true
     tmux set-option -wu -t "$win" @agent_name_user 2>/dev/null || true
     if [ "$user_name" = "<automatic>" ]; then
       tmux set-option -w -t "$win" automatic-rename on 2>/dev/null || true

--- a/nix/nixpkgs/overlays/custom/tmux-agent-status/tmux-agent-label.sh
+++ b/nix/nixpkgs/overlays/custom/tmux-agent-status/tmux-agent-label.sh
@@ -79,6 +79,23 @@ status="$(tmux show-option -wqv -t "$win" @agent_status 2>/dev/null || true)"
 # started later in this window does not inherit its predecessor's state.
 if [ -z "$icon" ]; then
   [ -z "$status" ] || tmux set-option -wu -t "$win" @agent_status 2>/dev/null || true
+  # `@agent_name_user` is the ownership marker set by tmux-agent-name on its first attempt:
+  # absent means the window's name was never touched and is not ours to manage.
+  # Present means restore the saved tab name (or re-enable auto-naming for the
+  # `<automatic>` sentinel, which must match tmux-agent-name) and drop all naming state.
+  user_name="$(tmux show-option -wqv -t "$win" @agent_name_user 2>/dev/null || true)"
+  if [ -n "$user_name" ]; then
+    tmux set-option -wu -t "$win" @agent_named 2>/dev/null || true
+    tmux set-option -wu -t "$win" @agent_name_material 2>/dev/null || true
+    tmux set-option -wu -t "$win" @agent_name_refresh 2>/dev/null || true
+    tmux set-option -wu -t "$win" @agent_name_tries 2>/dev/null || true
+    tmux set-option -wu -t "$win" @agent_name_user 2>/dev/null || true
+    if [ "$user_name" = "<automatic>" ]; then
+      tmux set-option -w -t "$win" automatic-rename on 2>/dev/null || true
+    else
+      tmux rename-window -t "$win" "$user_name" 2>/dev/null || true
+    fi
+  fi
   exit 0
 fi
 

--- a/nix/nixpkgs/overlays/custom/tmux-agent-status/tmux-agent-name.sh
+++ b/nix/nixpkgs/overlays/custom/tmux-agent-status/tmux-agent-name.sh
@@ -3,7 +3,8 @@
 #
 # The single entry point for all naming material: callers either push text they consider
 # a good task description, or ask the script to pull the agent-authored pane title.
-# The script owns the whole update sequence: state checks, the model call, sanitizing and the rename.
+# The name is distilled from that material locally (the summary is already the running agent's
+# own generation, so no external model is involved); the script owns the whole update sequence.
 #
 # Usage: tmux-agent-name set --source <kind> [options]
 #   --source title:      Pull the agent-authored pane title (the terminal summary channel).
@@ -18,21 +19,16 @@
 #   --emit-json: Print `{}` on exit for hook runners that expect JSON output (e.g. Gemini).
 #
 # Per-window state:
-#   @agent_named:         `pending` while a model call is in flight, then the chosen name.
-#   @agent_name_material: The material text the current name was derived from.
+#   @agent_name_material: The material the current name was derived from; dedupes re-fires.
 #   @agent_name_refresh:  Whether the name may still be updated; unset means true.
 #                         Stable sources (title, summary) keep it true and re-fire on change,
 #                         noisy ones (prompt, transcript) set it to false, locking the name.
-#   @agent_name_tries:    Failed model calls for the current material.
-#   @agent_name_user:     The tab name the window had before the first naming attempt
+#   @agent_name_user:     The tab name the window had before the first rename
 #                         (or the `<automatic>` sentinel when it was auto-named).
 #                         Doubles as the ownership marker: tmux-agent-label restores from it
 #                         and drops all of the state above when the agent exits.
 set -euo pipefail
 
-# How many failed model calls to tolerate per material before giving up on it.
-max_tries=3
-model=openrouter/auto
 # Must match the sentinel in tmux-agent-label.
 automatic_sentinel="<automatic>"
 
@@ -162,18 +158,50 @@ if [ -z "$material" ]; then
   exit 0
 fi
 
-named="$(tmux show-option -wqv -t "$win" @agent_named 2>/dev/null || true)"
 flag="$(tmux show-option -wqv -t "$win" @agent_name_refresh 2>/dev/null || true)"
 last="$(tmux show-option -wqv -t "$win" @agent_name_material 2>/dev/null || true)"
-if [ "$named" = "pending" ] || [ "$flag" = "false" ] || [ "$material" = "$last" ]; then
+if [ "$flag" = "false" ] || [ "$material" = "$last" ]; then
   finish
   exit 0
 fi
 
-# Take the lock before going async, so concurrent callers cannot double-fire.
-tmux set-option -w -t "$win" @agent_named pending 2>/dev/null || true
+# Distill a two-word tab name from the material. `stop` holds the words that carry no task
+# identity - articles, prepositions, and the generic verbs summaries open with - one arg each
+# so the whole-word matching below has clean boundaries.
+stop=" $(printf '%s ' \
+  a an the to in on of for and or with from into via new my this that is are be \
+  add adds added adding fix fixes fixed fixing update updates updated updating \
+  use uses used using make makes made making set sets setting \
+  create creates created creating investigate investigates investigated investigating \
+  analyze analyzes analyzed analyzing debug debugs debugged debugging \
+  refactor refactors refactored refactoring implement implements implemented implementing \
+  rewrite rewrites rewrote rewriting support supports supported supporting \
+  enable enables enabled enabling allow allows allowed allowing \
+  build builds built building run runs ran running \
+  check checks checked checking test tests tested testing)"
 
-# On the first attempt, remember the tab name the user had, so it can be restored on agent exit.
+# Lowercase, then split on anything that is not an identifier char (keeps foo_bar and foo-bar whole).
+words="$(printf '%s' "$material" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9_-' ' ')"
+
+# Keep the first two distinctive (non-stopword) tokens.
+name=""
+count=0
+for token in $words; do
+  case "$stop" in *" $token "*) continue ;; esac
+  name="$name $token"
+  count=$((count + 1))
+  [ "$count" -ge 2 ] && break
+done
+# An all-stopword summary falls back to its first two tokens verbatim.
+[ -n "$name" ] || name="$words"
+name="$(printf '%s' "$name" | tr -s ' ' '\n' | grep -m2 . | paste -sd- - | cut -c1-25 || true)"
+
+if [ -z "$name" ]; then
+  finish
+  exit 0
+fi
+
+# On the first rename, remember the tab name the user had, so it can be restored on agent exit.
 # A window-level `automatic-rename off` means the current name is a manual one worth keeping;
 # otherwise the window was auto-named and the sentinel says "hand naming back to tmux".
 if [ -z "$(tmux show-option -wqv -t "$win" @agent_name_user 2>/dev/null || true)" ]; then
@@ -185,52 +213,10 @@ if [ -z "$(tmux show-option -wqv -t "$win" @agent_name_user 2>/dev/null || true)
   tmux set-option -w -t "$win" @agent_name_user "$user_name" 2>/dev/null || true
 fi
 
-# The model call runs in the background, so a hook caller never delays its agent.
-(
-  # The router may land on reasoning models, which need a generous `max_tokens` to leave room
-  # for their thinking (an empty answer otherwise); only a few answer tokens are actually generated.
-  body="$(jq -n --arg m "$model" --arg t "$material" '{
-    model: $m,
-    max_tokens: 2000,
-    reasoning: {enabled: false},
-    messages: [{
-      role: "user",
-      content: ("Reply with EXACTLY TWO words most distinctively describing the task. "
-        + "No punctuation, no explanation. Task description: " + $t)
-    }]
-  }')"
-
-  # Latency is spiky, especially on free-pool models: usually seconds, sometimes closer to a minute.
-  name="$(curl -sS --max-time 90 https://openrouter.ai/api/v1/chat/completions \
-    -H "Authorization: Bearer ${OPENROUTER_API_KEY:-}" \
-    -H 'Content-Type: application/json' \
-    -d "$body" | jq -r '.choices[0].message.content // empty' || true)"
-
-  # Keep only the first two words, hyphen-joined, and strip whatever decoration the model added.
-  name="$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9_-' '\n' | grep -m2 . | paste -sd- - || true)"
-  name="${name:0:25}"
-
-  if [ -n "$name" ]; then
-    # `rename-window` also flips this window's automatic-rename off, so the name sticks.
-    tmux rename-window -t "$win" "$name" 2>/dev/null || true
-    tmux set-option -w -t "$win" @agent_named "$name" 2>/dev/null || true
-    tmux set-option -w -t "$win" @agent_name_material "$material" 2>/dev/null || true
-    tmux set-option -w -t "$win" @agent_name_refresh "$refresh" 2>/dev/null || true
-    tmux set-option -wu -t "$win" @agent_name_tries 2>/dev/null || true
-  else
-    # Models flake; release the lock so the caller may retry, but only a few times per material.
-    # On give-up the material is marked consumed anyway, so a later change starts fresh.
-    tries="$(tmux show-option -wqv -t "$win" @agent_name_tries 2>/dev/null || true)"
-    tries=$((${tries:-0} + 1))
-    if [ "$tries" -ge "$max_tries" ]; then
-      tmux set-option -w -t "$win" @agent_name_material "$material" 2>/dev/null || true
-      tmux set-option -wu -t "$win" @agent_name_tries 2>/dev/null || true
-    else
-      tmux set-option -w -t "$win" @agent_name_tries "$tries" 2>/dev/null || true
-    fi
-    tmux set-option -wu -t "$win" @agent_named 2>/dev/null || true
-  fi
-) </dev/null >/dev/null 2>&1 &
+# `rename-window` also flips this window's automatic-rename off, so the name sticks.
+tmux rename-window -t "$win" "$name" 2>/dev/null || true
+tmux set-option -w -t "$win" @agent_name_material "$material" 2>/dev/null || true
+tmux set-option -w -t "$win" @agent_name_refresh "$refresh" 2>/dev/null || true
 
 finish
 exit 0

--- a/nix/nixpkgs/overlays/custom/tmux-agent-status/tmux-agent-name.sh
+++ b/nix/nixpkgs/overlays/custom/tmux-agent-status/tmux-agent-name.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# Per-tab AI-generated tab NAME, sibling of tmux-agent-status.
+#
+# The single entry point for all naming material: callers either push text they consider
+# a good task description, or ask the script to pull the agent-authored pane title.
+# The script owns the whole update sequence: state checks, the model call, sanitizing and the rename.
+#
+# Usage: tmux-agent-name set --source <kind> [options]
+#   --source title:      Pull the agent-authored pane title (the terminal summary channel).
+#   --source summary:    An AI-generated summary passed explicitly with --text.
+#   --source prompt:     A user prompt, from --text or from hook JSON on stdin (`prompt` field).
+#   --source transcript: Best-effort extraction from the transcript file passed with --path.
+#
+# Options:
+#   --window <id> / --pane <id>: Target window and pane; by default derived from $TMUX_PANE,
+#                                which hooks inherit from the agent's own environment.
+#   --text <text> / --path <file>: The material, depending on the source.
+#   --emit-json: Print `{}` on exit for hook runners that expect JSON output (e.g. Gemini).
+#
+# Per-window state:
+#   @agent_named:         `pending` while a model call is in flight, then the chosen name.
+#   @agent_name_material: The material text the current name was derived from.
+#   @agent_name_refresh:  Whether the name may still be updated; unset means true.
+#                         Stable sources (title, summary) keep it true and re-fire on change,
+#                         noisy ones (prompt, transcript) set it to false, locking the name.
+#   @agent_name_tries:    Failed model calls for the current material.
+#   @agent_name_user:     The tab name the window had before the first naming attempt
+#                         (or the `<automatic>` sentinel when it was auto-named).
+#                         Doubles as the ownership marker: tmux-agent-label restores from it
+#                         and drops all of the state above when the agent exits.
+set -euo pipefail
+
+# How many failed model calls to tolerate per material before giving up on it.
+max_tries=3
+model=openrouter/auto
+# Must match the sentinel in tmux-agent-label.
+automatic_sentinel="<automatic>"
+
+cmd="${1:-}"
+[ $# -gt 0 ] && shift || true
+
+source_kind=""
+text=""
+path=""
+win=""
+pane=""
+emit_json=0
+
+if [ "$cmd" = "set" ]; then
+  while [ $# -gt 0 ]; do
+    case "$1" in
+    --source)
+      source_kind="${2:-}"
+      shift 2
+      ;;
+    --text)
+      text="${2:-}"
+      shift 2
+      ;;
+    --path)
+      path="${2:-}"
+      shift 2
+      ;;
+    --window)
+      win="${2:-}"
+      shift 2
+      ;;
+    --pane)
+      pane="${2:-}"
+      shift 2
+      ;;
+    --emit-json)
+      emit_json=1
+      shift
+      ;;
+    *) shift ;;
+    esac
+  done
+fi
+
+# Some hook runners pipe event JSON on stdin and expect JSON on stdout. Read stdin early
+# and bounded: it may carry prompt material, and draining it spares the writer an EPIPE.
+stdin_json=""
+[ -t 0 ] || stdin_json="$(timeout 0.5 cat 2>/dev/null || true)"
+finish() { [ "$emit_json" = 1 ] && printf '{}\n' || true; }
+
+# Usage errors are caller bugs and fail loudly, unlike the environmental no-ops
+# (outside tmux, no material yet, dedupe), which stay silent by design.
+# Exit 1, never 2: some hook runners interpret 2 as "block the agent's action".
+usage_error() {
+  printf 'tmux-agent-name: %s\n' "$1" >&2
+  finish
+  exit 1
+}
+
+[ "$cmd" = "set" ] || usage_error "unknown command: '${cmd}' (expected 'set')"
+[ -n "$source_kind" ] || usage_error "missing --source"
+
+# Resolve the target: an explicit --window wins, otherwise it is derived from the pane,
+# which itself defaults to $TMUX_PANE. No tmux context at all -> silent no-op.
+pane="${pane:-${TMUX_PANE:-}}"
+if [ -z "$win" ]; then
+  if [ -z "${TMUX:-}" ] || [ -z "$pane" ]; then
+    finish
+    exit 0
+  fi
+  win="$(tmux display-message -p -t "$pane" '#{window_id}' 2>/dev/null || true)"
+fi
+if [ -z "$win" ]; then
+  finish
+  exit 0
+fi
+
+# Agent-authored pane titles are prefixed with a spinner glyph from the U+2000-U+2FFF block,
+# whose UTF-8 encoding starts with byte 0xE2, while shell-written titles (paths, commands)
+# start with an ASCII character. `LC_ALL=C` makes the glob byte-wise, so the check works in any locale.
+title_is_agent_authored() {
+  local LC_ALL=C
+  case "$1" in
+  $'\xe2'*) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+material=""
+refresh="true"
+case "$source_kind" in
+title)
+  raw="$(tmux display-message -p -t "$pane" '#{pane_title}' 2>/dev/null || true)"
+  if title_is_agent_authored "$raw"; then
+    # Drop the animated spinner prefix, so the text compares stable across frames.
+    material="$(printf '%s' "$raw" | sed 's/^[^[:alnum:]]*//')"
+  fi
+  ;;
+summary)
+  [ -n "$text" ] || usage_error "--source summary requires --text"
+  material="$text"
+  ;;
+prompt)
+  material="$text"
+  [ -n "$material" ] || material="$(printf '%s' "$stdin_json" | jq -r '.prompt // empty' 2>/dev/null || true)"
+  refresh="false"
+  ;;
+transcript)
+  [ -n "$path" ] || usage_error "--source transcript requires --path"
+  [ -r "$path" ] || usage_error "transcript is not readable: ${path}"
+  # Transcripts are JSONL; prefer the latest summary entry, else the latest plain user message.
+  # The format is undocumented, so this is best-effort.
+  material="$(jq -rs '[.[] | select(.type == "summary") | .summary] | last // empty' "$path" 2>/dev/null || true)"
+  [ -n "$material" ] ||
+    material="$(jq -rs '[.[] | select(.type == "user") | .message.content | strings] | last // empty' \
+      "$path" 2>/dev/null || true)"
+  refresh="false"
+  ;;
+*) usage_error "unknown --source: '${source_kind}'" ;;
+esac
+
+# Cap the material, so a huge pasted prompt cannot bloat the model call.
+material="$(printf '%s' "$material" | head -c 500)"
+if [ -z "$material" ]; then
+  finish
+  exit 0
+fi
+
+named="$(tmux show-option -wqv -t "$win" @agent_named 2>/dev/null || true)"
+flag="$(tmux show-option -wqv -t "$win" @agent_name_refresh 2>/dev/null || true)"
+last="$(tmux show-option -wqv -t "$win" @agent_name_material 2>/dev/null || true)"
+if [ "$named" = "pending" ] || [ "$flag" = "false" ] || [ "$material" = "$last" ]; then
+  finish
+  exit 0
+fi
+
+# Take the lock before going async, so concurrent callers cannot double-fire.
+tmux set-option -w -t "$win" @agent_named pending 2>/dev/null || true
+
+# On the first attempt, remember the tab name the user had, so it can be restored on agent exit.
+# A window-level `automatic-rename off` means the current name is a manual one worth keeping;
+# otherwise the window was auto-named and the sentinel says "hand naming back to tmux".
+if [ -z "$(tmux show-option -wqv -t "$win" @agent_name_user 2>/dev/null || true)" ]; then
+  if [ "$(tmux show-option -wqv -t "$win" automatic-rename 2>/dev/null || true)" = "off" ]; then
+    user_name="$(tmux display-message -p -t "$win" '#{window_name}' 2>/dev/null || true)"
+  else
+    user_name="$automatic_sentinel"
+  fi
+  tmux set-option -w -t "$win" @agent_name_user "$user_name" 2>/dev/null || true
+fi
+
+# The model call runs in the background, so a hook caller never delays its agent.
+(
+  # The router may land on reasoning models, which need a generous `max_tokens` to leave room
+  # for their thinking (an empty answer otherwise); only a few answer tokens are actually generated.
+  body="$(jq -n --arg m "$model" --arg t "$material" '{
+    model: $m,
+    max_tokens: 2000,
+    reasoning: {enabled: false},
+    messages: [{
+      role: "user",
+      content: ("Reply with EXACTLY TWO words most distinctively describing the task. "
+        + "No punctuation, no explanation. Task description: " + $t)
+    }]
+  }')"
+
+  # Latency is spiky, especially on free-pool models: usually seconds, sometimes closer to a minute.
+  name="$(curl -sS --max-time 90 https://openrouter.ai/api/v1/chat/completions \
+    -H "Authorization: Bearer ${OPENROUTER_API_KEY:-}" \
+    -H 'Content-Type: application/json' \
+    -d "$body" | jq -r '.choices[0].message.content // empty' || true)"
+
+  # Keep only the first two words, hyphen-joined, and strip whatever decoration the model added.
+  name="$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9_-' '\n' | grep -m2 . | paste -sd- - || true)"
+  name="${name:0:25}"
+
+  if [ -n "$name" ]; then
+    # `rename-window` also flips this window's automatic-rename off, so the name sticks.
+    tmux rename-window -t "$win" "$name" 2>/dev/null || true
+    tmux set-option -w -t "$win" @agent_named "$name" 2>/dev/null || true
+    tmux set-option -w -t "$win" @agent_name_material "$material" 2>/dev/null || true
+    tmux set-option -w -t "$win" @agent_name_refresh "$refresh" 2>/dev/null || true
+    tmux set-option -wu -t "$win" @agent_name_tries 2>/dev/null || true
+  else
+    # Models flake; release the lock so the caller may retry, but only a few times per material.
+    # On give-up the material is marked consumed anyway, so a later change starts fresh.
+    tries="$(tmux show-option -wqv -t "$win" @agent_name_tries 2>/dev/null || true)"
+    tries=$((${tries:-0} + 1))
+    if [ "$tries" -ge "$max_tries" ]; then
+      tmux set-option -w -t "$win" @agent_name_material "$material" 2>/dev/null || true
+      tmux set-option -wu -t "$win" @agent_name_tries 2>/dev/null || true
+    else
+      tmux set-option -w -t "$win" @agent_name_tries "$tries" 2>/dev/null || true
+    fi
+    tmux set-option -wu -t "$win" @agent_named 2>/dev/null || true
+  fi
+) </dev/null >/dev/null 2>&1 &
+
+finish
+exit 0

--- a/nix/nixpkgs/overlays/custom/tmux-agent-status/tmux-agent-status.sh
+++ b/nix/nixpkgs/overlays/custom/tmux-agent-status/tmux-agent-status.sh
@@ -7,6 +7,59 @@
 # Usage: agent-status set --state <running|waiting|done|error|clear> [--emit-json]
 set -euo pipefail
 
+# Fire a desktop notification when the agent needs attention but its tmux session is not on screen.
+# The session counts as on screen when some client attached to it runs in the focused niri window;
+# the agent's own window may be a background tab, since the status icon in the tab bar
+# already shows its state. "Focused" implies "in viewport": niri scrolls a window into view
+# when focusing it, and exactly one window is focused globally, so multi-monitor and
+# scrollable-layout cases need no extra handling.
+#
+# The terminal is matched by pid, by walking each client's process ancestry
+# (client -> [shell ->] terminal) up to the pid niri reports for the focused window.
+# Pane processes themselves are children of the tmux server, not of any terminal,
+# which is why the walk must start from the client. Pid matching also avoids
+# depending on process names (on NixOS kitty's comm is `.kitty-wrapped`).
+maybe_notify() {
+  local state="$1" prev="$2" win="$3"
+  case "$state" in done | waiting | error) : ;; *) return 0 ;; esac
+  # Hooks re-fire the same state (e.g. repeated idle prompts); notify only on a real transition.
+  [ "$state" != "$prev" ] || return 0
+
+  # Outside niri the visibility question cannot be answered; stay silent rather than spam.
+  local focused_json focused_pid
+  focused_json="$(niri msg -j focused-window 2>/dev/null || true)"
+  [ -n "$focused_json" ] || return 0
+  # `null` (no focused window) is fine: the loop below matches nothing and the notification fires.
+  focused_pid="$(printf '%s' "$focused_json" | jq -r '.pid // empty' 2>/dev/null || true)"
+
+  local client_pid pid depth stat rest
+  while read -r client_pid; do
+    pid="$client_pid"
+    depth=0
+    while [ -n "$pid" ] && [ "$pid" != "$focused_pid" ] && [ "$depth" -lt 16 ]; do
+      stat="$(cat /proc/"$pid"/stat 2>/dev/null || true)"
+      [ -n "$stat" ] || break
+      # `stat` is `pid (comm) state ppid ...`, and comm may contain spaces
+      # (e.g. `tmux: server`), so strip through the last `)` before splitting.
+      rest="${stat##*) }"
+      rest="${rest#* }"
+      pid="${rest%% *}"
+      depth=$((depth + 1))
+    done
+    if [ -n "$pid" ] && [ "$pid" = "$focused_pid" ]; then
+      return 0 # The agent is on screen; no notification needed.
+    fi
+  done < <(tmux list-clients -t "$TMUX_PANE" -F '#{client_pid}' 2>/dev/null || true)
+
+  # The pane's foreground process is the agent itself: hooks run while it is still alive.
+  local agent
+  agent="$(tmux display-message -p -t "$TMUX_PANE" '#{pane_current_command}' 2>/dev/null || true)"
+  agent="${agent:-AI agent}"
+  # The window name (usually the AI-derived tab name) tells which task this is about.
+  notify-send -a "$agent" -u normal "$agent $state" \
+    "$(tmux display-message -p -t "$win" '#{window_name}' 2>/dev/null || true)" || true
+}
+
 cmd="${1:-}"
 [ $# -gt 0 ] && shift || true
 
@@ -55,9 +108,12 @@ esac
 
 win="$(tmux display-message -p -t "$TMUX_PANE" '#{window_id}' 2>/dev/null || true)"
 if [ -n "$win" ]; then
+  prev="$(tmux show-option -wqv -t "$win" @agent_status 2>/dev/null || true)"
   tmux set-option -w -t "$win" @agent_status "$state"
   # Force an immediate status redraw so the flip is instant.
   tmux refresh-client -S 2>/dev/null || true
+  # Hooks must never see notification plumbing on stderr, and must not fail over it.
+  maybe_notify "$state" "$prev" "$win" 2>/dev/null || true
 fi
 
 finish

--- a/nix/nixpkgs/overlays/custom/tmux-agent-status/tmux-agent-status.sh
+++ b/nix/nixpkgs/overlays/custom/tmux-agent-status/tmux-agent-status.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Per-tab agent STATUS icon (rendered after the tab name, via tmux-agent-label).
+#
+# The option stores the semantic state name; all presentation (glyphs, colors)
+# lives in tmux-agent-label, which renders the option into the status line.
+#
+# Usage: agent-status set --state <running|waiting|done|error|clear> [--emit-json]
+set -euo pipefail
+
+cmd="${1:-}"
+[ $# -gt 0 ] && shift || true
+
+state=""
+emit_json=0
+
+if [ "$cmd" = "set" ]; then
+  while [ $# -gt 0 ]; do
+    case "$1" in
+    --state)
+      state="${2:-}"
+      shift 2
+      ;;
+    --emit-json)
+      emit_json=1
+      shift
+      ;;
+    *) shift ;;
+    esac
+  done
+fi
+
+# Some agents (e.g. Gemini) expect the hook to print JSON on stdout, and pipe
+# the event JSON in on stdin. Drain stdin so the writer never sees EPIPE, but
+# cap it with a timeout: some hook runners leave stdin open and idle, and an
+# unbounded `cat` would hang the hook (and thus the agent) forever.
+[ -t 0 ] || timeout 0.2 cat >/dev/null 2>&1 || true
+finish() { [ "$emit_json" = 1 ] && printf '{}\n' || true; }
+
+# Nothing to set (unknown command, or no --state given).
+[ -n "$state" ] || {
+  finish
+  exit 0
+}
+
+# No-op outside tmux, or when we cannot tell which pane we belong to.
+if [ -z "${TMUX:-}" ] || [ -z "${TMUX_PANE:-}" ]; then
+  finish
+  exit 0
+fi
+
+case "$state" in
+running | waiting | done | error) : ;;
+*) state="" ;; # clear / unknown.
+esac
+
+win="$(tmux display-message -p -t "$TMUX_PANE" '#{window_id}' 2>/dev/null || true)"
+if [ -n "$win" ]; then
+  tmux set-option -w -t "$win" @agent_status "$state"
+  # Force an immediate status redraw so the flip is instant.
+  tmux refresh-client -S 2>/dev/null || true
+fi
+
+finish
+exit 0

--- a/nix/nixpkgs/overlays/vim-plugins.nix
+++ b/nix/nixpkgs/overlays/vim-plugins.nix
@@ -1,6 +1,15 @@
 _: final: prev: {
   unstable = prev.unstable // {
     vimPlugins = prev.unstable.vimPlugins // {
+      # The healthcheck crashes on neovim >= 0.11, which renamed the `vim.health.report_*` API.
+      # Upstream still uses the old names, and only `health.lua` is affected, so patch it in place.
+      # https://github.com/GCBallesteros/jupytext.nvim
+      jupytext-nvim = prev.unstable.vimPlugins.jupytext-nvim.overrideAttrs (old: {
+        postPatch = (old.postPatch or "") + ''
+          substituteInPlace lua/jupytext/health.lua --replace-fail "vim.health.report_" "vim.health."
+        '';
+      });
+
       # TODO(rudenkornk): remove this overlay once LazyVim supports all the quirks.
       # Special treatment for leap, which migrated to new repo and also rewritten some code.
       # LazyVim seemingly adapted, but for some reason it does not work.


### PR DESCRIPTION
- **refactor(desktop-envs): add explanation for different navigation keys in tmux and niri**
- **feat(vcs): some arcadia config amends**
- **feat(neovim): update blink AI provider icons**
- **feat(desktop-envs): reorganize some shortcuts**
- **feat(desktop-envs): fix missing toasts in noctalia-shell**
- **feat(ai): amend opencode keybinds**
- **fix(tmux): fix too broad tmux extended-keys forwarding**
- **feat(tmux): support short form for storage usage**
- **feat(tmux): shorten tmux status bar**
- **feat(desktop-envs): setup default apps for xdg-open**
- **fix(debuggers): expose DAP adapters under names LazyVim expects**
- **fix(neovim): fix missing jsregexp and other lua packages in neovim**
- **fix(lsp): install ansible-language-server binary**
- **fix(neovim): disable sidekick NES to drop copilot LSP**
- **fix(neovim): enable perl provider via withPerl**
- **fix(neovim): fix treesitter query errors from missing base modules**
- **feat(neovim): add inotify-tools for faster LSP file watching**
- **feat(lean): install lean4 toolchain (lake + lean)**
- **feat(search): add ast-grep for grug-far structural search**
- **feat(ai): add ast-grep skill**
- **fix(neovim): give snacks picker the sqlite3 library path**
- **fix(neovim): patch jupytext healthcheck for nvim 0.11+ api**
- **feat(neovim): install missing haskell toolchain**
- **feat(haskell): drop heavy haskell toolchain and neovim support**
- **feat(tmux): add support for agent status in tmux tabs**
- **feat(ai): add AI agent hooks for updating tmux tabs status**
- **feat(tmux): support automatic tab naming in tmux**
- **feat(ai): use automatic tab naming hook in AI agents**
- **feat(tmux): infer AI agent tab names with simple local heuristics**
- **feat(tmux): notify when agent finishes in off-viewport kitty terminal**
