### PR TITLE
dev volatile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -395,6 +395,14 @@ A small body is allowed only for notes about git ordering and implementation pla
 e.g. "Preparation for the upcoming change...", or how this commit relates to neighboring patches in a series.
 All information related to the code itself MUST live in the code (comments, docs), not in the commit message.
 
+### Exception: commits that delete code
+
+When a commit removes code — especially a workaround that is no longer needed — the rule above inverts.
+Deleted code has nowhere to live, so leaving behind a ghost comment describing what used to be there
+and why it went away just trades one piece of dead weight for another.
+Delete the code cleanly and put the explanation in the commit body instead, where `git log` and `git blame` will surface it
+for whoever wonders why the workaround disappeared.
+
 ## Trust These Instructions
 
 These instructions are comprehensive and tested. Only search for additional information if:

--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -160,7 +160,12 @@
     # System DNS resolver, providing per-link split-DNS for VPN connections.
     # Docker ignores the 127.0.0.53 stub in resolv.conf and falls back to public DNS,
     # so containers needing internal names may require explicit `daemon.json` dns.
-    resolved.enable = true;
+    resolved = {
+      enable = true;
+      # Avahi below already answers multicast DNS, and two stacks on one host make `.local` lookups unreliable,
+      # which avahi reports as "Detected another IPv4/IPv6 mDNS stack running on this host" at every boot.
+      settings.Resolve.MulticastDNS = "no";
+    };
 
     # https://wiki.nixos.org/wiki/Printing
     avahi = {

--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -126,11 +126,6 @@
 
     desktopManager.gnome = {
       enable = true;
-      extraGSettingsOverridePackages = [ pkgs.mutter ];
-      extraGSettingsOverrides = ''
-        [org.gnome.mutter]
-        experimental-features=['scale-monitor-framebuffer']
-      '';
     };
 
     power-profiles-daemon = {

--- a/nix/hosts/thinkpad.nix
+++ b/nix/hosts/thinkpad.nix
@@ -43,6 +43,10 @@
         kernelParams = [ "snd_intel_dspcfg.dsp_driver=3" ];
       };
 
+      # `lenovo-thinkpad-p15v-intel-gen3` unconditionally imports the NVIDIA PRIME and Turing modules,
+      # even though this machine (p16v) does not have nvidia gpu.
+      services.xserver.videoDrivers = [ "modesetting" ];
+
       nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
       hardware = {
         cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;


### PR DESCRIPTION
- **docs(agents): allow deletion rationale in commit body**
- **fix(thinkpad): do not load nvidia driver on a machine without one**
- **fix(gnome): drop mutter experimental feature removed in mutter 50**
- **fix(dns): let avahi own mdns instead of running two stacks**
